### PR TITLE
Upgrade gx-fov2box HDF5 stage schema, add IDL-parity tooling, and document model/viewer contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 *.h5
 build/
 *.egg-info*
+.DS_Store
+.vscode/

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,13 @@ Documentation
 Full documentation is available at:
 https://pyampp.readthedocs.io/en/latest/
 
+Format and viewer references:
+
+- Upgraded HDF5 stage format (NONE/BND/POT/NAS/NAS.GEN/NAS.CHR):
+  ``docs/model_hdf5_format.rst``
+- Viewer guide (``gxbox-view`` and ``gxrefmap-view``):
+  ``docs/viewers.rst``
+
 Overview
 --------
 
@@ -75,26 +82,43 @@ The instructions below use Conda as an example:
 Main Interfaces
 ---------------
 
-pyAMPP installs two GUI applications:
+pyAMPP provides a GUI for building a reproducible CLI command and separate tools for model generation and visualization:
 
-1. **gxampp** – Launches a GUI to select observation time and coordinates. It then invokes `gxbox` to build the 3D model.
-2. **gxbox** – Launches a GUI that builds and displays the 3D magnetic field and plasma model. Can be run independently if coordinates are known.
+1. **pyampp** – Launches a GUI to select observation time, coordinates, and options. It generates a `gx-fov2box` CLI command (shown above the Run button) and can launch it.
+2. **gx-fov2box** – Pure CLI model generator (IDL `gx_fov2box` equivalent). It saves the requested stages and records the full command in `metadata/execute`.
+3. **gxbox** – Launches the map GUI and 3D visualization for browsing existing models.
 
 Usage Examples
 --------------
 
-**1. Launch the time/coord selector (gxampp)**
+**1. Launch the time/coord selector (pyampp)**
 
 .. code-block:: bash
 
-    gxampp
+    pyampp
 
 .. image:: docs/images/pyampp_gui.png
     :alt: pyampp GUI screenshot
     :align: center
     :width: 600px
 
-**2. Launch the modeling GUI directly (Gxbox Map Viewer)**
+**2. Generate a model via CLI (gx-fov2box)**
+
+.. code-block:: bash
+
+    gx-fov2box \
+      --time "2022-03-30T17:22:37" \
+      --coords 34.44988566346035 14.26110705696788 \
+      --hgs \
+      --box-dims 360 180 200 \
+      --dx-km 1400 \
+      --pad-frac 0.25 \
+      --data-dir /path/to/download_dir \
+      --gxmodel-dir /path/to/gx_models_dir \
+      --save-potential \
+      --save-bounds
+
+**3. Launch the modeling GUI directly (Gxbox Map Viewer)**
 
 .. code-block:: bash
 
@@ -128,14 +152,18 @@ Notes:
 - `--coords` takes two floats, separated by space (no brackets or commas).
 - One of `--hpc`, `--hgc`, or `--hgs` must be specified to define the coordinate system.
 - Remaining parameters are optional and have default values.
+- Set ``PYAMPP_JSOC_NOTIFY_EMAIL`` to override the JSOC export notification email (default: ``suncasa-group@njit.edu``).
 
 Entrypoints
 -----------
 
 After installation, the following commands become available:
 
-- ``gxampp``: Launch the time and location GUI.
-- ``gxbox``: Launch the modeling GUI directly with CLI options.
+- ``pyampp``: Launch the command-builder GUI.
+- ``gx-fov2box``: Run the model-generation pipeline headlessly.
+- ``gxbox``: Launch the modeling/visualization GUI.
+- ``gxbox-view``: Open an existing HDF5 model in the 3D viewer.
+- ``gxrefmap-view``: Open base/refmaps from an HDF5 model in a 2D map browser.
 
 License
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,9 @@ This is the documentation for pyAMPP.
    :maxdepth: 2
    :caption: Contents:
 
+   model_hdf5_format
+   viewers
+
 Indices and tables
 ==================
 

--- a/docs/model_hdf5_format.rst
+++ b/docs/model_hdf5_format.rst
@@ -1,0 +1,82 @@
+pyAMPP HDF5 Model Format
+========================
+
+This page describes the upgraded HDF5 stage files produced by ``gx-fov2box`` and consumed by downstream tools.
+
+Common groups
+-------------
+
+All saved stages carry:
+
+- ``base``:
+  - ``bx``, ``by``, ``bz`` (2D)
+  - ``ic`` (2D)
+  - ``chromo_mask`` (2D)
+  - ``index`` (FITS-like header string; canonical base-map header)
+- ``refmaps``:
+  - per map: ``refmaps/<map_id>/data`` and ``refmaps/<map_id>/wcs_header``
+- ``metadata``:
+  - ``id`` (stage id string)
+  - ``execute`` (full command provenance)
+  - ``disambiguation`` (e.g. HMI/SFQ)
+  - ``projection`` (CEA/TOP)
+
+Each refmap carries its own ``wcs_header`` by design, so maps can be reconstructed independently.
+
+Stage-specific groups
+---------------------
+
+NONE
+~~~~
+
+- ``corona`` with zero-field placeholders and ``attrs/model_type = "none"``
+- ``grid`` with:
+  - ``voxel_id`` (uint32)
+  - ``dx``, ``dy``, ``dz``
+
+BND
+~~~
+
+- ``bounds`` group with boundary maps:
+  - ``bx``, ``by``, ``bz``, ``dr``
+
+POT
+~~~
+
+- ``corona`` group with potential extrapolation:
+  - ``bx``, ``by``, ``bz``, ``dr``
+  - ``attrs/model_type = "pot"``
+
+NAS
+~~~
+
+- ``corona`` group with NLFFF extrapolation:
+  - ``bx``, ``by``, ``bz``, ``dr``
+  - ``attrs/model_type = "nlfff"``
+
+NAS.GEN
+~~~~~~~
+
+- ``chromo`` includes generated line metadata needed for CHR completion:
+  - ``codes``, ``apex_idx``, ``start_idx``, ``end_idx``, ``seed_idx``
+  - ``av_field``, ``phys_length``, ``voxel_status``
+
+NAS.CHR
+~~~~~~~
+
+- ``chromo`` full chromospheric model payload (e.g. ``bcube``, ``chromo_bcube``, ``chromo_*``, ``dz``, etc.)
+- ``grid`` with final:
+  - ``voxel_id`` (uint32)
+  - ``dx``, ``dy``, ``dz``
+
+Dimension conventions
+---------------------
+
+- ``chromo/dz`` and ``grid/voxel_id`` use the same order: ``(nx, ny, nz)``.
+- Internal renderer arrays may be reordered for ABI compatibility; file-level convention remains ``(nx, ny, nz)``.
+
+IDL compatibility notes
+-----------------------
+
+- ``base/index`` is intended to be IDL-compatible metadata for base map geometry.
+- ``refmaps/*/wcs_header`` stores per-map WCS headers so IDL/Python viewers can reconstruct map coordinates.

--- a/docs/viewers.rst
+++ b/docs/viewers.rst
@@ -1,0 +1,58 @@
+Model Viewers
+=============
+
+gxbox-view
+----------
+
+``gxbox-view`` opens an existing model HDF5 file in the 3D viewer without recomputing.
+
+Expected inputs:
+
+- A model file containing at least one of:
+  - ``corona`` (preferred),
+  - ``nlfff`` / ``pot`` (accepted and normalized), or
+  - ``chromo`` with sufficient magnetic cube fields.
+
+Usage:
+
+.. code-block:: bash
+
+   gxbox-view /path/to/model.h5
+
+Optional file picker mode:
+
+.. code-block:: bash
+
+   gxbox-view --pick
+
+gxrefmap-view
+-------------
+
+``gxrefmap-view`` is a 2D map browser for base maps and refmaps stored in model HDF5 files.
+
+Expected layout:
+
+- Base maps:
+  - ``base/bx``, ``base/by``, ``base/bz``, ``base/ic``, ``base/chromo_mask``
+  - base header in ``base/index`` (fallbacks: ``base/index_header``, ``base/wcs_header``)
+- Refmaps:
+  - ``refmaps/<map_id>/data``
+  - ``refmaps/<map_id>/wcs_header``
+
+Usage:
+
+.. code-block:: bash
+
+   gxrefmap-view /path/to/model.h5
+
+List available maps only:
+
+.. code-block:: bash
+
+   gxrefmap-view /path/to/model.h5 --list
+
+Start from a specific map:
+
+.. code-block:: bash
+
+   gxrefmap-view /path/to/model.h5 --start AIA_94

--- a/pyampp/__init__.py
+++ b/pyampp/__init__.py
@@ -1,1 +1,3 @@
-__all__ = []
+from . import sfq
+
+__all__ = ["sfq"]

--- a/pyampp/data/downloader.py
+++ b/pyampp/data/downloader.py
@@ -228,7 +228,8 @@ class SDOImageDownloader:
         :return: A list of paths to the downloaded files.
         :rtype: list
         """
-        search_attrs = [a.Time(self.time, self.time), a.jsoc.Series(series), a.jsoc.Notify(JSOC_NOTIFY_EMAIL)]
+        notify_email = jsoc_notify_email()
+        search_attrs = [a.Time(self.time, self.time), a.jsoc.Series(series), a.jsoc.Notify(notify_email)]
         if wavelength:
             search_attrs.insert(-1, wavelength)  # Insert wavelength before notify
         if segments:

--- a/pyampp/gx_chromo/combo_model.py
+++ b/pyampp/gx_chromo/combo_model.py
@@ -16,8 +16,9 @@ def combo_model_idl(bndbox, box):
 
     return combo_model(box, dr, base_bz, base_ic)
 
-def combo_model(box, dr, base_bz, base_ic):
-    chromo_mask = decompose(base_bz, base_ic)
+def combo_model(box, dr, base_bz, base_ic, chromo_mask=None):
+    if chromo_mask is None:
+        chromo_mask = decompose(base_bz, base_ic)
     chromo = populate_chromo(chromo_mask)
 
     csize = chromo['nh'].shape

--- a/pyampp/gx_chromo/gx_voxelid.py
+++ b/pyampp/gx_chromo/gx_voxelid.py
@@ -1,0 +1,5 @@
+"""Compatibility shim: gx_voxelid now lives in pyampp.gxbox."""
+
+from pyampp.gxbox.gx_voxelid import gx_voxelid
+
+__all__ = ["gx_voxelid"]

--- a/pyampp/gxbox/UI/gxampp.ui
+++ b/pyampp/gxbox/UI/gxampp.ui
@@ -101,10 +101,37 @@
            </property>
           </widget>
          </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_jsoc_notify_email">
+           <property name="text">
+            <string>JSOC Notify Email:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLineEdit" name="jsoc_notify_email_edit">
+           <property name="toolTip">
+            <string>Email address used for JSOC export notifications.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <spacer name="spacer_jsoc_notify_email">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
+      </widget>
+     </item>
+    </layout>
     </item>
     <item>
      <widget class="QGroupBox" name="groupBox">
@@ -372,7 +399,7 @@
             <string>Padding as a percentage of box dimensions, increases each side of the box for extended margins.</string>
            </property>
            <property name="text">
-            <string>25</string>
+            <string>10</string>
            </property>
           </widget>
          </item>
@@ -478,6 +505,16 @@
         <property name="icon">
          <iconset>
           <normaloff>play.svg</normaloff>play.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="stop_button">
+        <property name="toolTip">
+         <string>Stop the running GXbox process</string>
+        </property>
+        <property name="text">
+         <string>Stop</string>
         </property>
        </widget>
       </item>

--- a/pyampp/gxbox/__init__.py
+++ b/pyampp/gxbox/__init__.py
@@ -1,3 +1,5 @@
 from pyampp.util.config import SAMPLE_DATA_DIR, DOWNLOAD_DIR
+from .gx_box2id import gx_box2id
+from .gx_voxelid import gx_voxelid
 
-__all__ = ['SAMPLE_DATA_DIR', 'DOWNLOAD_DIR']
+__all__ = ['SAMPLE_DATA_DIR', 'DOWNLOAD_DIR', 'gx_voxelid', 'gx_box2id']

--- a/pyampp/gxbox/box.py
+++ b/pyampp/gxbox/box.py
@@ -1,0 +1,170 @@
+import itertools
+from contextlib import nullcontext
+
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import SkyCoord
+from sunpy.coordinates import Helioprojective, HeliographicStonyhurst
+from sunpy.map import make_fitswcs_header
+try:
+    from sunpy.coordinates.screens import SphericalScreen
+except Exception:  # pragma: no cover
+    SphericalScreen = None
+
+
+class Box:
+    """
+    Represents a 3D box in solar or observer coordinates defined by its origin, center, dimensions, and resolution.
+
+    This class calculates and stores the coordinates of the box's edges, differentiating between bottom edges and other
+    edges. It is designed to integrate with solar physics data analysis frameworks such as SunPy and Astropy.
+    """
+
+    def __init__(self, frame_obs, box_origin, box_center, box_dims, box_res):
+        self._frame_obs = frame_obs
+        if hasattr(Helioprojective, "assume_spherical_screen"):
+            screen_ctx = Helioprojective.assume_spherical_screen(frame_obs.observer)
+        elif SphericalScreen is not None:
+            screen_ctx = SphericalScreen(frame_obs.observer)
+        else:
+            screen_ctx = nullcontext()
+        with (screen_ctx or nullcontext()):
+            self._origin = box_origin
+            self._center = box_center
+        self._dims = box_dims / u.pix * box_res
+        self._res = box_res
+        self._dims_pix = np.int_(box_dims.value)
+        self.corners = list(itertools.product(self._dims[0] / 2 * [-1, 1],
+                                              self._dims[1] / 2 * [-1, 1],
+                                              self._dims[2] / 2 * [-1, 1]))
+        self.edges = [edge for edge in itertools.combinations(self.corners, 2)
+                      if np.count_nonzero(u.Quantity(edge[0]) - u.Quantity(edge[1])) == 1]
+        self._bottom_edges = None
+        self._non_bottom_edges = None
+        self._calculate_edge_types()
+        self.b3dtype = ['pot', 'nlfff']
+        self.b3d = {"corona": None, "chromo": None}
+        self.corona_models = {}
+        self.corona_type = None
+
+    @property
+    def dims_pix(self):
+        return self._dims_pix
+
+    @property
+    def grid_coords(self):
+        return self._get_grid_coords(self._center)
+
+    def _get_grid_coords(self, grid_center):
+        grid_coords = {}
+        grid_coords['x'] = np.linspace(grid_center.x.to(self._dims.unit) - self._dims[0] / 2,
+                                       grid_center.x.to(self._dims.unit) + self._dims[0] / 2, self._dims_pix[0])
+        grid_coords['y'] = np.linspace(grid_center.y.to(self._dims.unit) - self._dims[1] / 2,
+                                       grid_center.y.to(self._dims.unit) + self._dims[1] / 2, self._dims_pix[1])
+        grid_coords['z'] = np.linspace(grid_center.z.to(self._dims.unit) - self._dims[2] / 2,
+                                       grid_center.z.to(self._dims.unit) + self._dims[2] / 2, self._dims_pix[2])
+        grid_coords['frame'] = self._frame_obs
+        return grid_coords
+
+    def _get_edge_coords(self, edges, box_center):
+        return [SkyCoord(x=box_center.x + u.Quantity([edge[0][0], edge[1][0]]),
+                         y=box_center.y + u.Quantity([edge[0][1], edge[1][1]]),
+                         z=box_center.z + u.Quantity([edge[0][2], edge[1][2]]),
+                         frame=box_center.frame) for edge in edges]
+
+    def _get_bottom_cea_header(self):
+        origin = self._origin.transform_to(HeliographicStonyhurst)
+        shape = self._dims[:-1][::-1] / self._res.to(self._dims.unit)
+        shape = list(shape.value)
+        shape = [int(np.ceil(s)) for s in shape]
+        rsun = origin.rsun.to(self._res.unit)
+        scale = np.arcsin(self._res / rsun).to(u.deg) / u.pix
+        scale = u.Quantity((scale, scale))
+        bottom_cea_header = make_fitswcs_header(shape, origin,
+                                                scale=scale, projection_code='CEA')
+        bottom_cea_header['OBSRVTRY'] = 'None'
+        return bottom_cea_header
+
+    def _get_bottom_top_header(self, dsun_obs=None):
+        origin = self._origin.transform_to(self._frame_obs)
+        shape = self._dims[:-1][::-1] / self._res.to(self._dims.unit)
+        shape = list(shape.value)
+        shape = [int(np.ceil(s)) for s in shape]
+        rsun = origin.rsun.to(self._res.unit)
+        if dsun_obs is None:
+            dsun_obs = origin.observer.radius.to(self._res.unit)
+        else:
+            dsun_obs = u.Quantity(dsun_obs).to(self._res.unit)
+        # Match IDL TOP scaling: dx_arcsec ~ dx_km / (DSUN_OBS - RSUN).
+        scale = ((self._res / (dsun_obs - rsun)).to(u.dimensionless_unscaled) * u.rad).to(u.arcsec) / u.pix
+        scale = u.Quantity((scale, scale))
+        bottom_top_header = make_fitswcs_header(shape, origin, scale=scale, projection_code='TAN')
+        bottom_top_header['OBSRVTRY'] = 'None'
+        return bottom_top_header
+
+    def _calculate_edge_types(self):
+        min_z = min(corner[2] for corner in self.corners)
+        bottom_edges, non_bottom_edges = [], []
+        for edge in self.edges:
+            if edge[0][2] == min_z and edge[1][2] == min_z:
+                bottom_edges.append(edge)
+            else:
+                non_bottom_edges.append(edge)
+        self._bottom_edges = self._get_edge_coords(bottom_edges, self._center)
+        self._non_bottom_edges = self._get_edge_coords(non_bottom_edges, self._center)
+
+    def _get_bounds_coords(self, edges, bltr=False, pad_frac=0.0):
+        xx = []
+        yy = []
+        for edge in edges:
+            xx.append(edge.transform_to(self._frame_obs).Tx)
+            yy.append(edge.transform_to(self._frame_obs).Ty)
+        unit = xx[0][0].unit
+        min_x = np.min(xx)
+        max_x = np.max(xx)
+        min_y = np.min(yy)
+        max_y = np.max(yy)
+        if pad_frac > 0:
+            _pad = pad_frac * np.max([max_x - min_x, max_y - min_y, 20])
+            min_x -= _pad
+            max_x += _pad
+            min_y -= _pad
+            max_y += _pad
+        if bltr:
+            bottom_left = SkyCoord(min_x * unit, min_y * unit, frame=self._frame_obs)
+            top_right = SkyCoord(max_x * unit, max_y * unit, frame=self._frame_obs)
+            return [bottom_left, top_right]
+        else:
+            coords = SkyCoord(Tx=[min_x, max_x] * unit, Ty=[min_y, max_y] * unit,
+                              frame=self._frame_obs)
+            return coords
+
+    def bounds_coords_bl_tr(self, pad_frac=0.0):
+        return self._get_bounds_coords(self.all_edges, bltr=True, pad_frac=pad_frac)
+
+    @property
+    def bounds_coords(self):
+        return self._get_bounds_coords(self.all_edges)
+
+    @property
+    def bottom_bounds_coords(self):
+        return self._get_bounds_coords(self.bottom_edges)
+
+    @property
+    def bottom_cea_header(self):
+        return self._get_bottom_cea_header()
+
+    def bottom_top_header(self, dsun_obs=None):
+        return self._get_bottom_top_header(dsun_obs=dsun_obs)
+
+    @property
+    def bottom_edges(self):
+        return self._bottom_edges
+
+    @property
+    def non_bottom_edges(self):
+        return self._non_bottom_edges
+
+    @property
+    def all_edges(self):
+        return self.bottom_edges + self.non_bottom_edges

--- a/pyampp/gxbox/boxutils.py
+++ b/pyampp/gxbox/boxutils.py
@@ -1,5 +1,106 @@
 import numpy as np
 import astropy.units as u
+from astropy.io import fits
+
+def _bilinear_sample(arr: np.ndarray, x: np.ndarray, y: np.ndarray) -> np.ndarray:
+    x0 = np.floor(x).astype(int)
+    y0 = np.floor(y).astype(int)
+    x1 = x0 + 1
+    y1 = y0 + 1
+
+    x0 = np.clip(x0, 0, arr.shape[0] - 1)
+    x1 = np.clip(x1, 0, arr.shape[0] - 1)
+    y0 = np.clip(y0, 0, arr.shape[1] - 1)
+    y1 = np.clip(y1, 0, arr.shape[1] - 1)
+
+    wx = x - x0
+    wy = y - y0
+
+    f00 = arr[x0, y0]
+    f10 = arr[x1, y0]
+    f01 = arr[x0, y1]
+    f11 = arr[x1, y1]
+
+    return (f00 * (1 - wx) * (1 - wy) +
+            f10 * wx * (1 - wy) +
+            f01 * (1 - wx) * wy +
+            f11 * wx * wy)
+
+
+def _vxv(a: np.ndarray, b: np.ndarray, norm: bool = False) -> np.ndarray:
+    c = np.array([
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ], dtype=float)
+    if norm:
+        n = np.sqrt((c * c).sum())
+        if n > 0:
+            c /= n
+    return c
+
+
+def compute_vertical_current(b0: np.ndarray,
+                             b1: np.ndarray,
+                             b2: np.ndarray,
+                             wcs_header: str,
+                             rsun_arcsec: float,
+                             crpix1: float | None = None,
+                             crpix2: float | None = None,
+                             cdelt1_arcsec: float | None = None,
+                             cdelt2_arcsec: float | None = None) -> np.ndarray:
+    if crpix1 is None or crpix2 is None or cdelt1_arcsec is None or cdelt2_arcsec is None:
+        header = fits.Header.fromstring(wcs_header, sep="\n")
+        cdelt1 = header.get("CDELT1")
+        cdelt2 = header.get("CDELT2")
+        cunit1 = header.get("CUNIT1", "deg")
+        cunit2 = header.get("CUNIT2", "deg")
+        crpix1 = header.get("CRPIX1")
+        crpix2 = header.get("CRPIX2")
+
+        if cdelt1 is None or cdelt2 is None or crpix1 is None or crpix2 is None:
+            raise ValueError("WCS header missing CDELT/CRPIX values.")
+
+        cdelt1_arcsec = (cdelt1 * u.Unit(cunit1)).to_value(u.arcsec)
+        cdelt2_arcsec = (cdelt2 * u.Unit(cunit2)).to_value(u.arcsec)
+
+    jr = np.zeros_like(b0, dtype=float)
+    nx, ny = b0.shape
+
+    delta = 0.5 * cdelt1_arcsec / rsun_arcsec
+
+    for i1 in range(1, nx - 1):
+        for i2 in range(1, ny - 1):
+            x1 = (i1 - crpix1) * cdelt1_arcsec / rsun_arcsec
+            x2 = (i2 - crpix2) * cdelt2_arcsec / rsun_arcsec
+            if np.sqrt(x1 * x1 + x2 * x2) >= 0.95:
+                continue
+            x0 = np.sqrt(1.0 - x1 * x1 - x2 * x2)
+
+            e0 = np.array([x0, x1, x2], dtype=float)
+            e1 = _vxv(np.array([0.0, 0.0, 1.0], dtype=float), e0, norm=True)
+            e2 = _vxv(e0, e1, norm=False)
+
+            x1s = np.array([-e1[1], e1[1], -e2[1], e2[1]]) * delta + x1
+            x2s = np.array([-e1[2], e1[2], -e2[2], e2[2]]) * delta + x2
+
+            xx1 = x1s * rsun_arcsec / cdelt1_arcsec + crpix1
+            xx2 = x2s * rsun_arcsec / cdelt2_arcsec + crpix2
+
+            b0_int = _bilinear_sample(b0, xx1, xx2) * 1e-4
+            b1_int = _bilinear_sample(b1, xx1, xx2) * 1e-4
+            b2_int = _bilinear_sample(b2, xx1, xx2) * 1e-4
+
+            term_e2 = (b0_int[1] * e2[0] + b1_int[1] * e2[1] + b2_int[1] * e2[2]) - \
+                      (b0_int[0] * e2[0] + b1_int[0] * e2[1] + b2_int[0] * e2[2])
+            term_e1 = (b0_int[3] * e1[0] + b1_int[3] * e1[1] + b2_int[3] * e1[2]) - \
+                      (b0_int[2] * e1[0] + b1_int[2] * e1[1] + b2_int[2] * e1[2])
+
+            jr[i1, i2] = (term_e2 - term_e1)
+            jr[i1, i2] /= 2 * (delta * 696e6) * (4 * np.pi * 1e-7)
+
+    return jr
+import astropy.units as u
 from astropy.coordinates import SkyCoord
 from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst
 from sunpy.map import all_coordinates_from_map, Map
@@ -154,7 +255,10 @@ def validate_number(func):
 
     def wrapper(self, widget, *args, **kwargs):
         try:
-            float(widget.text().strip())
+            if hasattr(widget, "value"):
+                float(widget.value())
+            else:
+                float(widget.text().strip())
         except ValueError:
             QMessageBox.warning(self, "Invalid Input", "Please enter a valid number.")
             return
@@ -195,10 +299,11 @@ def read_gxsim_b3d_sav(savfile):
     #     gxboxdata = pickle.load(f)
     gxboxdata = {}
     gxboxdata['b3d'] = {}
-    gxboxdata['b3d']['nlfff'] = {}
-    gxboxdata['b3d']['nlfff']['bx'] = bx.swapaxes(0,2)
-    gxboxdata['b3d']['nlfff']['by'] = by.swapaxes(0,2)
-    gxboxdata['b3d']['nlfff']['bz'] = bz.swapaxes(0,2)
+    gxboxdata['b3d']['corona'] = {}
+    gxboxdata['b3d']['corona']['bx'] = bx.swapaxes(0,2)
+    gxboxdata['b3d']['corona']['by'] = by.swapaxes(0,2)
+    gxboxdata['b3d']['corona']['bz'] = bz.swapaxes(0,2)
+    gxboxdata['b3d']['corona']["attrs"] = {"model_type": "nlfff"}
     boxfilenew = savfile.replace('.sav', '.gxbox')
     with open(boxfilenew, 'wb') as f:
         pickle.dump(gxboxdata, f)
@@ -210,9 +315,9 @@ def read_b3d_h5(filename):
     Read B3D data from an HDF5 file and populate a dictionary.
 
     The resulting dictionary will contain keys corresponding to different
-    magnetic field models (e.g., 'pot' for potential fields and 'nlfff' for
-    nonlinear force-free fields), and each model will have sub-keys for
-    the magnetic field components (e.g., 'bx', 'by', 'bz').
+    magnetic field models (e.g., 'corona' for coronal fields and 'chromo' for
+    chromospheric fields), and each model will have sub-keys for the magnetic
+    field components (e.g., 'bx', 'by', 'bz').
 
     :param filename: str,
         The path to the HDF5 file.
@@ -225,25 +330,46 @@ def read_b3d_h5(filename):
 
         b3dbox = read_b3d_h5('path_to_file.h5')
 
-        # Get the potential field components
-        bx_pot = b3dbox['pot']['bx']
-        by_pot = b3dbox['pot']['by']
-        bz_pot = b3dbox['pot']['bz']
-
-        # Get the NLFFF field components
-        bx_nlf = b3dbox['nlfff']['bx']
-        by_nlf = b3dbox['nlfff']['by']
-        bz_nlf = b3dbox['nlfff']['bz']
+        # Get the coronal field components
+        bx_cor = b3dbox['corona']['bx']
+        by_cor = b3dbox['corona']['by']
+        bz_cor = b3dbox['corona']['bz']
     """
     box_b3d = {}
     with h5py.File(filename, 'r') as hdf_file:
         for model_type in hdf_file.keys():
             group = hdf_file[model_type]
-            box_b3d[model_type] = {}
+            target_type = model_type
+            model_attr = None
+            if model_type in ("nlfff", "pot", "potential"):
+                target_type = "corona"
+                model_attr = "pot" if model_type == "potential" else model_type
+            if target_type not in box_b3d:
+                box_b3d[target_type] = {}
             for component in group.keys():
-                box_b3d[model_type][component] = group[component][:]
-            if len(group.attrs.keys()) > 0:
-                box_b3d[model_type]["attrs"] = dict(group.attrs)
+                ds = group[component]
+                if isinstance(ds, h5py.Group):
+                    sub = {}
+                    for sub_key in ds.keys():
+                        sub_ds = ds[sub_key]
+                        if sub_ds.shape == ():
+                            sub[sub_key] = sub_ds[()]
+                        else:
+                            sub[sub_key] = sub_ds[:]
+                    box_b3d[target_type][component] = sub
+                else:
+                    if ds.shape == ():
+                        box_b3d[target_type][component] = ds[()]
+                    else:
+                        box_b3d[target_type][component] = ds[:]
+            if len(group.attrs.keys()) > 0 or model_attr is not None:
+                attrs = dict(group.attrs)
+                if model_attr is not None and "model_type" not in attrs:
+                    attrs["model_type"] = model_attr
+                if "attrs" in box_b3d[target_type]:
+                    box_b3d[target_type]["attrs"].update(attrs)
+                else:
+                    box_b3d[target_type]["attrs"] = attrs
     return box_b3d
 
 def write_b3d_h5(filename, box_b3d):
@@ -261,9 +387,49 @@ def write_b3d_h5(filename, box_b3d):
             if components is None:
                 print(f"Warning: {model_type} components are None, skipping.")
                 continue
-            group = hdf_file.create_group(model_type)
+            if model_type == "metadata":
+                group = hdf_file.create_group("metadata")
+                for key, value in components.items():
+                    if isinstance(value, str):
+                        group.create_dataset(key, data=np.bytes_(value))
+                    else:
+                        group.create_dataset(key, data=value)
+                continue
+            target_type = model_type
+            attrs = components.get("attrs", {}) if isinstance(components, dict) else {}
+            if model_type in ("nlfff", "pot", "potential"):
+                target_type = "corona"
+                if "model_type" not in attrs:
+                    attrs = dict(attrs)
+                    attrs["model_type"] = "pot" if model_type == "potential" else model_type
+            if target_type in hdf_file:
+                # Avoid collisions if multiple legacy groups map to corona
+                continue
+            group = hdf_file.create_group(target_type)
             for component, data in components.items():
                 if component == "attrs":
-                    group.attrs.update(data)
+                    continue
+                if isinstance(data, dict):
+                    sub = group.create_group(component)
+                    for sub_key, sub_val in data.items():
+                        if target_type == "chromo" and sub_key == "voxel_status":
+                            sub.create_dataset(sub_key, data=np.asarray(sub_val, dtype=np.uint8))
+                        else:
+                            sub.create_dataset(sub_key, data=sub_val)
                 else:
-                    group.create_dataset(component, data=data)
+                    if target_type == "chromo" and component == "voxel_status":
+                        group.create_dataset(component, data=np.asarray(data, dtype=np.uint8))
+                    else:
+                        group.create_dataset(component, data=data)
+            if attrs:
+                group.attrs.update(attrs)
+
+
+# Backward-compatible SFQ exports.
+from pyampp.sfq import get_str_mag as get_str_mag
+from pyampp.sfq import sfq_frame as sfq_frame
+from pyampp.sfq import sfq_step1 as sfq_step1
+from pyampp.sfq import sfq_clean as sfq_clean
+from pyampp.sfq import pex_bl_ as pex_bl_
+from pyampp.sfq import pex_bl as pex_bl
+from pyampp.sfq import pot_vmag as pot_vmag

--- a/pyampp/gxbox/gx_box2id.py
+++ b/pyampp/gxbox/gx_box2id.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .gx_voxelid import gx_voxelid
+
+
+def _has_tag(box, name: str) -> bool:
+    if isinstance(box, dict):
+        return name in box
+    return hasattr(box, name)
+
+
+def _get_tag(box, name: str, default=None):
+    if isinstance(box, dict):
+        return box.get(name, default)
+    return getattr(box, name, default)
+
+
+def _find_field(box, candidates: tuple[str, ...]):
+    for name in candidates:
+        if _has_tag(box, name):
+            return _get_tag(box, name)
+    return None
+
+
+def _gx_tr_height_sunradius() -> float:
+    """IDL parity for gx_tr_height(): 2000 / gx_rsun(km)."""
+    return 2000.0 / 696000.0
+
+
+def _normalize_box_for_id(box):
+    """Accept either a flat AMPP box dict or a full HDF5-style dict with grouped fields."""
+    if not isinstance(box, dict):
+        return box
+    if "corona" not in box and "chromo" not in box:
+        return box
+    chromo = box.get("chromo", {}) if isinstance(box.get("chromo", {}), dict) else {}
+    corona = box.get("corona", {}) if isinstance(box.get("corona", {}), dict) else {}
+    merged = {}
+    # Coronal field provides the base volume size (IDL Bx/By/Bz or bcube equivalent).
+    for key in ("bx", "by", "bz", "Bx", "By", "Bz", "bcube", "dr", "start_idx", "startidx"):
+        if key in corona:
+            merged[key] = corona[key]
+    # Chromo-specific tags used by gx_box2id.
+    for key in ("chromo_idx", "chromo_t", "chromo_n", "chromo_layers", "corona_base"):
+        if key in chromo:
+            merged[key] = chromo[key]
+    # Also accept flat tags already present at top level.
+    for key in ("bx", "by", "bz", "Bx", "By", "Bz", "bcube", "dr", "start_idx", "startidx",
+                "chromo_idx", "chromo_t", "chromo_n", "chromo_layers", "corona_base"):
+        if key in box and key not in merged:
+            merged[key] = box[key]
+    return merged if merged else box
+
+
+def gx_box2id(box, tr_mask: np.ndarray | None = None):
+    """Build voxel_id 3D array from an AMPP/GX box structure.
+
+    Port of IDL `gx_box2id.pro` with parity-oriented behavior.
+    """
+    if box is None:
+        return None
+    box = _normalize_box_for_id(box)
+
+    bx = _find_field(box, ("Bx", "bx"))
+    by = _find_field(box, ("By", "by"))
+    bz = _find_field(box, ("Bz", "bz"))
+    valid_bxbybz = bx is not None and by is not None and bz is not None
+    bcube = _find_field(box, ("bcube",))
+    valid_b = bcube is not None
+    if not (valid_bxbybz or valid_b):
+        return None
+
+    dr = np.asarray(_find_field(box, ("dr",)), dtype=float)
+    if dr.size < 3:
+        raise ValueError("box.dr must contain at least 3 elements.")
+
+    if _has_tag(box, "corona_base"):
+        corona_base = int(_get_tag(box, "corona_base"))
+    else:
+        start_idx = _find_field(box, ("startidx", "start_idx"))
+        if start_idx is not None:
+            start_idx = np.asarray(start_idx)
+            nonzero_vals = start_idx[start_idx != 0]
+            if nonzero_vals.size > 0:
+                # IDL array_indices parity: interpret indices in Fortran order.
+                _, _, z_idx = np.unravel_index(nonzero_vals.astype(np.int64), start_idx.shape, order="F")
+                corona_base = int(np.min(z_idx))
+            else:
+                corona_base = int(np.ceil(_gx_tr_height_sunradius() / dr[2]))
+        else:
+            corona_base = int(np.ceil(_gx_tr_height_sunradius() / dr[2]))
+
+    chromo_layers = int(_get_tag(box, "chromo_layers", corona_base))
+
+    if valid_bxbybz:
+        sz = np.asarray(np.shape(bx), dtype=int)
+    else:
+        sz = np.asarray(np.shape(bcube[..., 0]), dtype=int)
+    if sz.size != 3:
+        raise ValueError("Expected magnetic field volume with shape (nx, ny, nz).")
+
+    out_sz = sz.copy()
+    if corona_base > 0:
+        out_sz[2] = out_sz[2] - corona_base + chromo_layers
+    nx, ny, nz = (int(out_sz[0]), int(out_sz[1]), int(out_sz[2]))
+
+    vid = np.zeros((nx, ny, nz), dtype=np.uint32)
+    tr = np.zeros((nx, ny), dtype=np.uint32)
+
+    has_combo = (
+        _has_tag(box, "chromo_idx")
+        and _has_tag(box, "chromo_t")
+        and _has_tag(box, "chromo_n")
+    )
+    if has_combo:
+        vol_t = np.zeros((nx, ny, nz), dtype=float)
+        vol_n = np.zeros((nx, ny, nz), dtype=float)
+
+        chromo_idx = np.asarray(_get_tag(box, "chromo_idx"), dtype=np.int64)
+        chromo_t = np.asarray(_get_tag(box, "chromo_t"), dtype=float)
+        chromo_n = np.asarray(_get_tag(box, "chromo_n"), dtype=float)
+
+        # IDL parity: flat indexing in Fortran order.
+        vtf = vol_t.ravel(order="F")
+        vnf = vol_n.ravel(order="F")
+        nfill = min(chromo_idx.size, chromo_t.size, chromo_n.size)
+        valid = (chromo_idx[:nfill] >= 0) & (chromo_idx[:nfill] < vtf.size)
+        idx = chromo_idx[:nfill][valid]
+        vtf[idx] = chromo_t[:nfill][valid]
+        vnf[idx] = chromo_n[:nfill][valid]
+        vol_t = vtf.reshape(vol_t.shape, order="F")
+        vol_n = vnf.reshape(vol_n.shape, order="F")
+
+        for i in range(nx):
+            for j in range(ny):
+                k = np.where((vol_n[i, j, :] != 0) & (vol_t[i, j, :] != 0))[0]
+                tr[i, j] = np.uint32((int(np.max(k)) + 1) if k.size else 0)
+    else:
+        tr[:, :] = np.uint32(max(corona_base, 0))
+
+    max_tr = int(np.max(tr))
+    if max_tr >= 0:
+        k_end = min(max_tr + 1, nz)
+        vid[:, :, 0:k_end] = gx_voxelid(chromo=True)
+
+    tr_euv = gx_voxelid(tr=True, euvtr=True)
+    cor = gx_voxelid(corona=True)
+    for i in range(nx):
+        for j in range(ny):
+            k = int(tr[i, j])
+            if 0 <= k < nz:
+                vid[i, j, k] = np.uint32(vid[i, j, k] + tr_euv)
+                vid[i, j, k:nz] = np.uint32(vid[i, j, k:nz] + cor)
+
+    # Mark EUV-active TR IDs for corona voxels neighboring chromo voxels.
+    cor_chromo_id = gx_voxelid(chromo=True, corona=True)
+    coridx = np.where(vid.ravel(order="F") == cor_chromo_id)[0]
+    if coridx.size > 0:
+        flat = vid.ravel(order="F")
+        valid = (coridx > 0) & (coridx < flat.size - 1)
+        coridx_v = coridx[valid]
+        if coridx_v.size > 0:
+            edge = np.where((flat[coridx_v + 1] == 1) | (flat[coridx_v - 1] == 1))[0]
+            if edge.size > 0:
+                flat[coridx_v[edge]] = np.uint32(flat[coridx_v[edge]] + tr_euv)
+                vid = flat.reshape(vid.shape, order="F")
+
+    if tr_mask is not None:
+        tr_mask = np.asarray(tr_mask)
+        if tr_mask.shape[0] == nx and tr_mask.shape[1] == ny:
+            mask = np.uint32(1) - np.asarray(tr_mask, dtype=np.uint32)
+            tr_euv_mask = gx_voxelid(tr=True, euvtr=True)
+            flat = vid.ravel(order="F")
+            tr_idx = np.where((flat & tr_euv_mask) != 0)[0]
+            if tr_idx.size > 0:
+                xi, yi, _ = np.unravel_index(tr_idx, vid.shape, order="F")
+                euv = gx_voxelid(euvtr=True)
+                flat[tr_idx] = np.uint32(flat[tr_idx] - mask[xi, yi] * euv)
+                vid = flat.reshape(vid.shape, order="F")
+
+    return vid

--- a/pyampp/gxbox/gx_fov2box.py
+++ b/pyampp/gxbox/gx_fov2box.py
@@ -254,6 +254,8 @@ def _build_index_header(bottom_wcs_header, source_map: Map) -> str:
                 header["CRLN_OBS"] = float(obs_hgc.lon.to_value(u.deg))
                 header["CRLT_OBS"] = float(obs_hgc.lat.to_value(u.deg))
             except Exception:
+                # If Carrington transformation fails (e.g. unsupported observer configuration),
+                # proceed without CRLN_OBS/CRLT_OBS rather than aborting header creation.
                 # Carrington observer transforms can fail for some observer metadata;
                 # keep header generation robust and proceed with available keys.
                 pass

--- a/pyampp/gxbox/gx_fov2box.py
+++ b/pyampp/gxbox/gx_fov2box.py
@@ -1,0 +1,890 @@
+import shlex
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Any, Optional, Tuple
+
+import astropy.units as u
+import numpy as np
+import typer
+from astropy.coordinates import SkyCoord
+from astropy.time import Time
+from astropy.io import fits
+from pyAMaFiL.mag_field_lin_fff import MagFieldLinFFF
+from pyAMaFiL.mag_field_proc import MagFieldProcessor
+from sunpy.coordinates import (Heliocentric, HeliographicCarrington, HeliographicStonyhurst,
+                               Helioprojective, get_earth)
+from sunpy.map import Map
+from sunpy.sun import constants as sun_consts
+
+from pyampp.data.downloader import SDOImageDownloader
+from pyampp.gx_chromo.combo_model import combo_model
+from pyampp.gx_chromo.decompose import decompose
+from pyampp.gxbox.box import Box
+from pyampp.gxbox.boxutils import hmi_b2ptr, hmi_disambig, read_b3d_h5, write_b3d_h5, compute_vertical_current
+from pyampp.gxbox.gx_box2id import gx_box2id
+from pyampp.util.config import DOWNLOAD_DIR, GXMODEL_DIR, AIA_EUV_PASSBANDS, AIA_UV_PASSBANDS
+
+
+app = typer.Typer(help="Run gx_fov2box pipeline without GUI and save model stages.")
+
+
+@dataclass
+class Fov2BoxConfig:
+    time: Optional[str]
+    coords: Optional[Tuple[float, float]]
+    hpc: bool
+    hgc: bool
+    hgs: bool
+    cea: bool
+    top: bool
+    box_dims: Optional[Tuple[int, int, int]]
+    dx_km: float
+    pad_frac: float
+    data_dir: str
+    gxmodel_dir: str
+    entry_box: Optional[str]
+    save_empty_box: bool
+    save_potential: bool
+    save_bounds: bool
+    save_nas: bool
+    save_gen: bool
+    save_chr: bool
+    stop_after: Optional[str]
+    empty_box_only: bool
+    potential_only: bool
+    nlfff_only: bool
+    generic_only: bool
+    use_potential: bool
+    center_vox: bool
+    reduce_passed: Optional[int]
+    euv: bool
+    uv: bool
+    sfq: bool
+    jump2potential: bool
+    jump2nlfff: bool
+    jump2lines: bool
+    jump2chromo: bool
+    info: bool
+
+
+def _infer_time_from_path(path: Path) -> Optional[str]:
+    stem = path.name
+    if "hmi.M_720s." in stem:
+        try:
+            tag = stem.split("hmi.M_720s.", 1)[1].split(".", 1)[0]
+            if len(tag) == 15:
+                return f"{tag[0:4]}-{tag[4:6]}-{tag[6:8]}T{tag[9:11]}:{tag[11:13]}:{tag[13:15]}"
+        except Exception:
+            return None
+    return None
+
+
+def _format_coord_tag(lon_deg: float, lat_deg: float, suffix: str = "CR") -> str:
+    lon = (lon_deg + 180.0) % 360.0 - 180.0
+    lon_dir = "W" if lon >= 0 else "E"
+    lat_dir = "N" if lat_deg >= 0 else "S"
+    lon_val = f"{abs(int(round(lon))):02d}"
+    lat_val = f"{abs(int(round(lat_deg))):02d}"
+    return f"{lon_dir}{lon_val}{lat_dir}{lat_val}{suffix}"
+
+
+def _stage_output_dir(gxmodel_dir: str, obs_time: Time) -> Path:
+    date_str = obs_time.to_datetime().strftime("%Y-%m-%d")
+    out_dir = Path(gxmodel_dir) / date_str
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def _stage_file_base(obs_time: Time, coord_tag: str, projection_tag: str = "CEA") -> str:
+    time_tag = obs_time.to_datetime().strftime("%Y%m%d_%H%M%S")
+    return f"hmi.M_720s.{time_tag}.{coord_tag}.{projection_tag}"
+
+
+def _stage_filename(out_dir: Path, base: str, stage_tag: str) -> Path:
+    return out_dir / f"{base}.{stage_tag}.h5"
+
+
+def _last_stage_tag(stop_after: Optional[str]) -> str:
+    if stop_after:
+        stop = stop_after.lower()
+        if stop in ("none", "empty", "empty_box"):
+            return "NONE"
+        if stop in ("bnd", "bounds"):
+            return "BND"
+        if stop == "pot":
+            return "POT"
+        if stop == "nas":
+            return "NAS"
+        if stop == "gen":
+            return "NAS.GEN"
+        if stop == "chr":
+            return "NAS.CHR"
+    return "NAS.CHR"
+
+
+def _should_save_stage(stage_tag: str, cfg: Fov2BoxConfig) -> bool:
+    if stage_tag == _last_stage_tag(cfg.stop_after):
+        return True
+    if stage_tag == "POT":
+        return cfg.save_potential
+    if stage_tag == "NAS":
+        return cfg.save_nas
+    if stage_tag == "NAS.GEN":
+        return cfg.save_gen
+    if stage_tag == "NAS.CHR":
+        return cfg.save_chr
+    if stage_tag == "NONE":
+        return cfg.save_empty_box
+    if stage_tag == "BND":
+        return cfg.save_bounds
+    return False
+
+
+def _build_execute_cmd(cfg: Fov2BoxConfig) -> str:
+    cmd = ["gx-fov2box"]
+    if cfg.time:
+        cmd += ["--time", cfg.time]
+    if cfg.coords:
+        cmd += ["--coords", str(cfg.coords[0]), str(cfg.coords[1])]
+    if cfg.hpc:
+        cmd.append("--hpc")
+    elif cfg.hgc:
+        cmd.append("--hgc")
+    else:
+        cmd.append("--hgs")
+    if cfg.top:
+        cmd.append("--top")
+    elif cfg.cea:
+        cmd.append("--cea")
+    if cfg.box_dims:
+        cmd += ["--box-dims", *(str(v) for v in cfg.box_dims)]
+    cmd += ["--dx-km", f"{cfg.dx_km:.6f}"]
+    cmd += ["--pad-frac", f"{cfg.pad_frac:.4f}"]
+    cmd += ["--data-dir", cfg.data_dir]
+    cmd += ["--gxmodel-dir", cfg.gxmodel_dir]
+    cmd += ["--euv" if cfg.euv else "--no-euv"]
+    cmd += ["--uv" if cfg.uv else "--no-uv"]
+    if cfg.save_empty_box:
+        cmd.append("--save-empty-box")
+    if cfg.save_potential:
+        cmd.append("--save-potential")
+    if cfg.save_bounds:
+        cmd.append("--save-bounds")
+    if cfg.save_nas:
+        cmd.append("--save-nas")
+    if cfg.save_gen:
+        cmd.append("--save-gen")
+    if cfg.save_chr:
+        cmd.append("--save-chr")
+    if cfg.empty_box_only:
+        cmd.append("--empty-box-only")
+    if cfg.potential_only:
+        cmd.append("--potential-only")
+    if cfg.nlfff_only:
+        cmd.append("--nlfff-only")
+    if cfg.generic_only:
+        cmd.append("--generic-only")
+    if cfg.use_potential:
+        cmd.append("--use-potential")
+    if cfg.center_vox:
+        cmd.append("--center-vox")
+    if cfg.reduce_passed is not None:
+        cmd += ["--reduce-passed", str(cfg.reduce_passed)]
+    if cfg.entry_box:
+        cmd += ["--entry-box", cfg.entry_box]
+    if cfg.sfq:
+        cmd.append("--sfq")
+    if cfg.stop_after:
+        cmd += ["--stop-after", cfg.stop_after]
+    if cfg.jump2potential:
+        cmd.append("--jump2potential")
+    if cfg.jump2nlfff:
+        cmd.append("--jump2nlfff")
+    if cfg.jump2lines:
+        cmd.append("--jump2lines")
+    if cfg.jump2chromo:
+        cmd.append("--jump2chromo")
+    return shlex.join(cmd)
+
+
+def _build_index_header(bottom_wcs_header, source_map: Map) -> str:
+    """
+    Build an IDL-GX compatible INDEX-like FITS header string.
+
+    This mirrors the intent of IDL `wcs2fitshead(..., /structure)` for the
+    base map WCS: preserve WCS cards and add key TIME/POSITION cards expected
+    by legacy GX Simulator routines.
+    """
+    header = fits.Header(bottom_wcs_header).copy()
+
+    # Normalize to IDL-GX conventions used in box.index.
+    ctype1 = str(header.get("CTYPE1", ""))
+    ctype2 = str(header.get("CTYPE2", ""))
+    if ctype1.startswith("HGLN-"):
+        header["CTYPE1"] = "CRLN-" + ctype1.split("-", 1)[1]
+    if ctype2.startswith("HGLT-"):
+        header["CTYPE2"] = "CRLT-" + ctype2.split("-", 1)[1]
+
+    header["SIMPLE"] = int(bool(header.get("SIMPLE", 1)))
+    header["BITPIX"] = int(header.get("BITPIX", 8))
+    header["NAXIS"] = int(header.get("NAXIS", 2))
+
+    if source_map is not None:
+        date_obs = source_map.date.isot if source_map.date is not None else None
+        if date_obs:
+            header["DATE-OBS"] = date_obs
+            header["DATE_OBS"] = date_obs
+            header["DATE"] = date_obs
+        elif "DATE-OBS" in header and "DATE_OBS" not in header:
+            header["DATE_OBS"] = header["DATE-OBS"]
+
+        if hasattr(source_map, "dsun") and source_map.dsun is not None:
+            header["DSUN_OBS"] = float(source_map.dsun.to_value(u.m))
+
+        obs = source_map.observer_coordinate
+        if obs is not None:
+            obs_hgs = obs.transform_to(HeliographicStonyhurst(obstime=source_map.date))
+            header["HGLN_OBS"] = float(obs_hgs.lon.to_value(u.deg))
+            header["HGLT_OBS"] = float(obs_hgs.lat.to_value(u.deg))
+            header["SOLAR_B0"] = float(obs_hgs.lat.to_value(u.deg))
+            try:
+                obs_hgc = obs.transform_to(HeliographicCarrington(observer="earth", obstime=source_map.date))
+                header["CRLN_OBS"] = float(obs_hgc.lon.to_value(u.deg))
+                header["CRLT_OBS"] = float(obs_hgc.lat.to_value(u.deg))
+            except Exception:
+                pass
+
+        if getattr(source_map, "rsun_meters", None) is not None:
+            header["RSUN_REF"] = float(source_map.rsun_meters.to_value(u.m))
+
+        tel = source_map.meta.get("telescop")
+        if tel:
+            header["TELESCOP"] = str(tel)
+        instr = source_map.meta.get("instrume")
+        if instr:
+            header["INSTRUME"] = str(instr)
+        if "WCSNAME" not in header:
+            header["WCSNAME"] = "Carrington-Heliographic"
+
+    return header.tostring(sep="\n", endcard=True)
+
+
+def _print_info(cfg: Fov2BoxConfig) -> None:
+    resolved_reduce_passed = cfg.reduce_passed if cfg.reduce_passed is not None else (0 if cfg.center_vox else 1)
+    import pyampp
+    import sunpy
+
+    runtime_rows = [
+        ("python_executable", sys.executable, "Interpreter used for this run"),
+        ("python_version", sys.version.split()[0], "Python runtime version"),
+        ("gx_fov2box_module", __file__, "Loaded gx_fov2box module path"),
+        ("pyampp_module", pyampp.__file__, "Loaded pyampp package path"),
+        ("sunpy_version", sunpy.__version__, "Loaded sunpy version"),
+        ("gx-fov2box_cli", shutil.which("gx-fov2box"), "Resolved CLI entry point on PATH"),
+    ]
+    rows = [
+        ("time", cfg.time, "Observation time in ISO format"),
+        ("coords", cfg.coords, "Center coordinates: arcsec (HPC) or degrees (HGC/HGS)"),
+        ("hpc/hgc/hgs", "HPC" if cfg.hpc else "HGC" if cfg.hgc else "HGS", "Coordinate frame"),
+        ("cea/top", "TOP" if cfg.top else "CEA", "Basemap projection"),
+        ("box_dims", cfg.box_dims, "Box dimensions (nx, ny, nz) in pixels"),
+        ("dx_km", cfg.dx_km, "Voxel size in km"),
+        ("pad_frac", cfg.pad_frac, "Padding fraction used for context map FOV"),
+        ("data_dir", cfg.data_dir, "SDO download/cache directory"),
+        ("gxmodel_dir", cfg.gxmodel_dir, "Output gx_models directory"),
+        ("entry_box", cfg.entry_box, "Path to precomputed HDF5 box"),
+        ("save_empty_box", cfg.save_empty_box, "Save NONE stage"),
+        ("save_potential", cfg.save_potential, "Save POT stage"),
+        ("save_bounds", cfg.save_bounds, "Save BND stage"),
+        ("save_nas", cfg.save_nas, "Save NAS stage"),
+        ("save_gen", cfg.save_gen, "Save NAS.GEN stage"),
+        ("save_chr", cfg.save_chr, "Save NAS.CHR stage"),
+        ("stop_after", cfg.stop_after, "Stop after stage (none/bnd/pot/nas/gen/chr)"),
+        ("empty_box_only", cfg.empty_box_only, "Stop after NONE stage"),
+        ("potential_only", cfg.potential_only, "Stop after POT stage"),
+        ("nlfff_only", cfg.nlfff_only, "Stop after NAS stage"),
+        ("generic_only", cfg.generic_only, "Stop after NAS.GEN stage"),
+        ("use_potential", cfg.use_potential, "Skip NLFFF; reuse potential field"),
+        ("center_vox", cfg.center_vox, "Compute lines only through voxel centers (sets reduce_passed=0 unless overridden)"),
+        ("reduce_passed", cfg.reduce_passed, "Expert override: 0|1|2|3 (takes precedence over --center-vox)"),
+        ("reduce_passed_resolved", resolved_reduce_passed, "Effective line-reduction mode used by tracer"),
+        ("euv", cfg.euv, "Download AIA EUV context maps"),
+        ("uv", cfg.uv, "Download AIA UV context maps"),
+        ("sfq", cfg.sfq, "Use SFQ disambiguation (method=0)"),
+        ("jump2potential", cfg.jump2potential, "Start from entry box and jump to POT"),
+        ("jump2nlfff", cfg.jump2nlfff, "Start from entry box and jump to NAS"),
+        ("jump2lines", cfg.jump2lines, "Start from entry box and jump to GEN"),
+        ("jump2chromo", cfg.jump2chromo, "Start from entry box and jump to CHR"),
+    ]
+    print("gx-fov2box --info")
+    for name, value, desc in runtime_rows + rows:
+        print(f"- {name}: {value} :: {desc}")
+    missing = []
+    if not cfg.time:
+        missing.append("--time")
+    if not cfg.coords:
+        missing.append("--coords")
+    if not cfg.box_dims:
+        missing.append("--box-dims")
+    if missing:
+        print("\nWarnings:")
+        for item in missing:
+            print(f"- Missing required {item}")
+        if cfg.entry_box:
+            print("- entry_box provided; time/box-dims may be inferred if present")
+
+
+def _load_hmi_maps_from_downloader(
+    time: Time,
+    data_dir: Path,
+    euv: bool,
+    uv: bool,
+    disambig_method: int = 2,
+) -> tuple[Dict[str, Map], dict]:
+    import time as time_mod
+
+    downloader = SDOImageDownloader(time, data_dir=str(data_dir), euv=euv, uv=uv, hmi=True)
+    missing_before = []
+    if downloader.existence_report:
+        for category in ("hmi_b", "hmi_m", "hmi_ic"):
+            items = downloader.existence_report.get(category, {})
+            missing_before.extend([k for k, exists in items.items() if not exists])
+    t0 = time_mod.perf_counter()
+    files = downloader.download_images()
+    elapsed = time_mod.perf_counter() - t0
+    downloaded = len(missing_before) > 0
+    required = ["field", "inclination", "azimuth", "disambig", "continuum", "magnetogram"]
+    missing = [k for k in required if not files.get(k)]
+    if missing:
+        raise RuntimeError(f"Missing required HMI files: {missing}")
+
+    map_field = Map(files["field"])
+    map_inclination = Map(files["inclination"])
+    map_azimuth = Map(files["azimuth"])
+    map_disambig = Map(files["disambig"])
+    map_conti = Map(files["continuum"])
+    map_losma = Map(files["magnetogram"])
+
+    map_azimuth = hmi_disambig(map_azimuth, map_disambig, method=disambig_method)
+
+    maps = {
+        "field": map_field,
+        "inclination": map_inclination,
+        "azimuth": map_azimuth,
+        "disambig": map_disambig,
+        "continuum": map_conti,
+        "magnetogram": map_losma,
+    }
+    for key, path in files.items():
+        if key in ("field", "inclination", "azimuth", "disambig", "continuum", "magnetogram"):
+            continue
+        try:
+            maps[f"AIA_{key}"] = Map(path)
+        except Exception:
+            continue
+    info = {"downloaded": downloaded, "elapsed": elapsed, "missing_before": missing_before}
+    return maps, info
+
+
+def _make_header(map_field: Map) -> Dict[str, Any]:
+    header_field = map_field.wcs.to_header()
+    field_frame = map_field.center.heliographic_carrington.frame
+    lon, lat = field_frame.lon.value, field_frame.lat.value
+    obs_time = Time(map_field.date)
+    dsun_obs = header_field["DSUN_OBS"]
+    return {"lon": lon, "lat": lat, "dsun_obs": dsun_obs, "obs_time": str(obs_time.iso)}
+
+
+def _make_gen_chromo(chromo_box: dict) -> dict:
+    gen_keys = [
+        "dr",
+        "bcube",
+        "start_idx",
+        "end_idx",
+        "av_field",
+        "phys_length",
+        "voxel_status",
+        "apex_idx",
+        "codes",
+        "seed_idx",
+    ]
+    gen = {k: chromo_box[k] for k in gen_keys if k in chromo_box}
+    if "attrs" in chromo_box:
+        gen["attrs"] = chromo_box["attrs"]
+    return gen
+
+
+def _resolve_box_params(cfg: Fov2BoxConfig) -> Tuple[Time, Tuple[int, int, int], float]:
+    obs_time = Time(cfg.time) if cfg.time else None
+    box_dims = cfg.box_dims
+    dx_km = cfg.dx_km
+    if cfg.entry_box:
+        entry_path = Path(cfg.entry_box)
+        if entry_path.exists() and entry_path.suffix == ".h5":
+            box_b3d = read_b3d_h5(str(entry_path))
+            corona = box_b3d.get("corona")
+            if corona is not None:
+                if box_dims is None and "bx" in corona:
+                    box_dims = corona["bx"].shape
+                if "dr" in corona and dx_km == 0:
+                    dr3 = corona["dr"]
+                    dx_km = float(dr3[0] * sun_consts.radius.to(u.km).value)
+        if obs_time is None:
+            inferred = _infer_time_from_path(entry_path)
+            if inferred:
+                obs_time = Time(inferred)
+    if obs_time is None:
+        raise ValueError("--time is required unless it can be inferred from entry_box")
+    if box_dims is None:
+        raise ValueError("--box-dims is required unless it can be inferred from entry_box")
+    return obs_time, tuple(int(v) for v in box_dims), float(dx_km)
+
+
+@app.command()
+def main(
+    time: Optional[str] = typer.Option(None, "--time", help="Observation time ISO (e.g. 2024-05-12T00:00:00)"),
+    coords: Optional[Tuple[float, float]] = typer.Option(None, "--coords", help="Center coords (x y)"),
+    hpc: bool = typer.Option(False, "--hpc/--no-hpc", help="Use helioprojective coordinates"),
+    hgc: bool = typer.Option(False, "--hgc/--no-hgc", help="Use heliographic carrington coordinates"),
+    hgs: bool = typer.Option(False, "--hgs/--no-hgs", help="Use heliographic stonyhurst coordinates"),
+    cea: bool = typer.Option(False, "--cea", help="Use CEA basemap projection"),
+    top: bool = typer.Option(False, "--top", help="Use TOP-view basemap projection"),
+    box_dims: Optional[Tuple[int, int, int]] = typer.Option(None, "--box-dims", help="Box dims in pixels"),
+    dx_km: float = typer.Option(1400.0, "--dx-km", help="Voxel size in km"),
+    pad_frac: float = typer.Option(0.10, "--pad-frac", help="Padding fraction for FOV"),
+    data_dir: str = typer.Option(DOWNLOAD_DIR, "--data-dir", help="SDO data directory"),
+    gxmodel_dir: str = typer.Option(GXMODEL_DIR, "--gxmodel-dir", help="GX model output directory"),
+    entry_box: Optional[str] = typer.Option(None, "--entry-box", help="Existing HDF5 box"),
+    save_empty_box: bool = typer.Option(False, "--save-empty-box", help="Save NONE stage"),
+    save_potential: bool = typer.Option(False, "--save-potential", help="Save POT stage"),
+    save_bounds: bool = typer.Option(False, "--save-bounds", help="Save BND stage"),
+    save_nas: bool = typer.Option(False, "--save-nas", help="Save NAS stage"),
+    save_gen: bool = typer.Option(False, "--save-gen", help="Save NAS.GEN stage"),
+    save_chr: bool = typer.Option(False, "--save-chr", help="Save NAS.CHR stage"),
+    stop_after: Optional[str] = typer.Option(None, "--stop-after", help="Stop after stage"),
+    empty_box_only: bool = typer.Option(False, "--empty-box-only", help="Stop after NONE"),
+    potential_only: bool = typer.Option(False, "--potential-only", help="Stop after POT"),
+    nlfff_only: bool = typer.Option(False, "--nlfff-only", help="Stop after NAS"),
+    generic_only: bool = typer.Option(False, "--generic-only", help="Stop after NAS.GEN"),
+    use_potential: bool = typer.Option(False, "--use-potential", help="Skip NLFFF"),
+    center_vox: bool = typer.Option(False, "--center-vox", help="Trace lines through voxel centers"),
+    reduce_passed: Optional[int] = typer.Option(
+        None,
+        "--reduce-passed",
+        min=0,
+        max=3,
+        help="Expert line tracing reduction bitmask: 0|1|2|3 (overrides --center-vox)",
+    ),
+    euv: bool = typer.Option(True, "--euv/--no-euv", help="Download AIA EUV maps"),
+    uv: bool = typer.Option(True, "--uv/--no-uv", help="Download AIA UV maps"),
+    sfq: bool = typer.Option(False, "--sfq", help="Use SFQ disambiguation (method=0)"),
+    jump2potential: bool = typer.Option(False, "--jump2potential", help="Jump to POT"),
+    jump2nlfff: bool = typer.Option(False, "--jump2nlfff", help="Jump to NAS"),
+    jump2lines: bool = typer.Option(False, "--jump2lines", help="Jump to GEN"),
+    jump2chromo: bool = typer.Option(False, "--jump2chromo", help="Jump to CHR"),
+    info: bool = typer.Option(False, "--info", help="Show resolved defaults and exit"),
+) -> None:
+    cfg = Fov2BoxConfig(
+        time=time,
+        coords=coords,
+        hpc=hpc,
+        hgc=hgc,
+        hgs=hgs,
+        cea=cea,
+        top=top,
+        box_dims=box_dims,
+        dx_km=dx_km,
+        pad_frac=pad_frac,
+        data_dir=data_dir,
+        gxmodel_dir=gxmodel_dir,
+        entry_box=entry_box,
+        save_empty_box=save_empty_box,
+        save_potential=save_potential,
+        save_bounds=save_bounds,
+        save_nas=save_nas,
+        save_gen=save_gen,
+        save_chr=save_chr,
+        stop_after=stop_after,
+        empty_box_only=empty_box_only,
+        potential_only=potential_only,
+        nlfff_only=nlfff_only,
+        generic_only=generic_only,
+        use_potential=use_potential,
+        center_vox=center_vox,
+        reduce_passed=reduce_passed,
+        euv=euv,
+        uv=uv,
+        sfq=sfq,
+        jump2potential=jump2potential,
+        jump2nlfff=jump2nlfff,
+        jump2lines=jump2lines,
+        jump2chromo=jump2chromo,
+        info=info,
+    )
+
+    if not any([cfg.hpc, cfg.hgc, cfg.hgs]):
+        cfg.hpc = True
+    if cfg.cea and cfg.top:
+        raise ValueError("Select only one projection: --cea or --top")
+    if not cfg.cea and not cfg.top:
+        cfg.cea = True
+
+    if cfg.empty_box_only:
+        cfg.stop_after = cfg.stop_after or "none"
+    elif cfg.potential_only:
+        cfg.stop_after = cfg.stop_after or "pot"
+    elif cfg.nlfff_only:
+        cfg.stop_after = cfg.stop_after or "nas"
+    elif cfg.generic_only:
+        cfg.stop_after = cfg.stop_after or "gen"
+
+    if cfg.info:
+        _print_info(cfg)
+        return
+
+    import time as time_mod
+    import warnings
+    import logging
+
+    t_start = time_mod.perf_counter()
+    warnings.filterwarnings("ignore", message=".*assume_spherical_screen.*")
+    logging.getLogger("reproject").setLevel(logging.WARNING)
+    logging.getLogger("sunpy").setLevel(logging.WARNING)
+
+    obs_time, box_dims_resolved, dx_km = _resolve_box_params(cfg)
+    cfg.dx_km = dx_km
+
+    if cfg.coords is None:
+        raise ValueError("--coords is required")
+    if sum([cfg.hpc, cfg.hgc, cfg.hgs]) != 1:
+        raise ValueError("Select exactly one of --hpc, --hgc, --hgs")
+    jump_flags_set = any([cfg.jump2potential, cfg.jump2nlfff, cfg.jump2lines, cfg.jump2chromo])
+    if jump_flags_set and not cfg.entry_box:
+        print("Warning: jump2* flags are ignored unless --entry-box is provided.")
+
+    import time as time_mod
+
+    observer = get_earth(obs_time)
+
+    data_dir_path = Path(cfg.data_dir).expanduser().resolve()
+    disambig_method = 0 if cfg.sfq else 2
+    maps, download_info = _load_hmi_maps_from_downloader(
+        obs_time, data_dir_path, cfg.euv, cfg.uv, disambig_method=disambig_method
+    )
+    if download_info["downloaded"]:
+        print(f"HMI data: downloaded missing files in {download_info['elapsed']:.2f}s.")
+    else:
+        print("HMI data: already present in local repository.")
+
+    rsun = u.Quantity(maps["field"].rsun_meters, u.m).to(u.km)
+
+    if cfg.hpc:
+        box_origin = SkyCoord(cfg.coords[0] * u.arcsec, cfg.coords[1] * u.arcsec,
+                              obstime=obs_time, observer=observer, rsun=rsun, frame=Helioprojective)
+    elif cfg.hgc:
+        box_origin = SkyCoord(lon=cfg.coords[0] * u.deg, lat=cfg.coords[1] * u.deg,
+                              radius=rsun, obstime=obs_time, observer=observer,
+                              frame=HeliographicCarrington)
+    else:
+        box_origin = SkyCoord(lon=cfg.coords[0] * u.deg, lat=cfg.coords[1] * u.deg,
+                              radius=rsun, obstime=obs_time, observer=observer,
+                              frame=HeliographicStonyhurst)
+
+    box_dims_q = u.Quantity(list(box_dims_resolved)) * u.pix
+    box_res = (cfg.dx_km * u.km).to(u.Mm)
+
+    frame_obs = Helioprojective(observer=observer, obstime=obs_time, rsun=rsun)
+    frame_hcc = Heliocentric(observer=box_origin, obstime=obs_time)
+    box_center = box_origin.transform_to(frame_hcc)
+    center_z = box_center.z + (box_dims_q[2] / u.pix * box_res) / 2
+    box_center = SkyCoord(x=box_center.x, y=box_center.y, z=center_z, frame=frame_hcc)
+
+    box = Box(frame_obs, box_origin, box_center, box_dims_q, box_res)
+    if cfg.top:
+        bottom_wcs_header = box.bottom_top_header(dsun_obs=maps["field"].dsun)
+        projection_tag = "TOP"
+    else:
+        bottom_wcs_header = box.bottom_cea_header
+        projection_tag = "CEA"
+    fov_coords = box.bounds_coords_bl_tr(pad_frac=cfg.pad_frac)
+
+    map_bp, map_bt, map_br = hmi_b2ptr(maps["field"], maps["inclination"], maps["azimuth"])
+
+    def submap_with_fov(_map: Map) -> Map:
+        bl = fov_coords[0].transform_to(_map.coordinate_frame)
+        tr = fov_coords[1].transform_to(_map.coordinate_frame)
+        return _map.submap(bl, top_right=tr)
+
+    map_bp = submap_with_fov(map_bp)
+    map_bt = submap_with_fov(map_bt)
+    map_br = submap_with_fov(map_br)
+    map_cont = submap_with_fov(maps["continuum"])
+    map_los = submap_with_fov(maps["magnetogram"])
+
+    map_bx = Map(-map_bt.data, map_bt.meta)
+    map_by = map_bp
+    map_bz = map_br
+
+    bottom_bx = map_bx.reproject_to(bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+    bottom_by = map_by.reproject_to(bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+    bottom_bz = map_bz.reproject_to(bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+
+    base_bz = map_los.reproject_to(bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+    base_ic = map_cont.reproject_to(bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+
+    index = _build_index_header(bottom_wcs_header, bottom_bz)
+    chromo_mask = decompose(base_bz.data.T, base_ic.data.T)
+    base_group = {
+        "bx": bottom_bx.data,
+        "by": bottom_by.data,
+        "bz": bottom_bz.data,
+        "ic": base_ic.data,
+        "chromo_mask": chromo_mask,
+        "index": index,
+    }
+
+    refmaps = {}
+    def add_refmap(ref_id: str, smap: Map) -> None:
+        smap = submap_with_fov(smap)
+        # Use WCS header only to avoid non-ASCII FITS meta from some sources.
+        header = smap.wcs.to_header()
+        refmaps[ref_id] = {"data": smap.data, "wcs_header": header.tostring(sep="\\n", endcard=True)}
+
+    add_refmap("Bz_reference", maps["magnetogram"])
+    add_refmap("Ic_reference", maps["continuum"])
+
+    vert_current_error = None
+    try:
+        vc_header = map_bx.wcs.to_header().tostring(sep="\\n", endcard=True)
+        rsun_arcsec = maps["magnetogram"].rsun_obs.to_value(u.arcsec)
+        crpix1, crpix2 = map_bx.wcs.wcs.crpix
+        cdelt1 = map_bx.scale.axis1.to_value(u.arcsec / u.pix)
+        cdelt2 = map_bx.scale.axis2.to_value(u.arcsec / u.pix)
+        jz = compute_vertical_current(map_bz.data, map_bx.data, map_by.data,
+                                      vc_header, rsun_arcsec,
+                                      crpix1=crpix1, crpix2=crpix2,
+                                      cdelt1_arcsec=cdelt1, cdelt2_arcsec=cdelt2)
+        refmaps["Vert_current"] = {"data": jz, "wcs_header": vc_header}
+    except Exception as exc:
+        vert_current_error = str(exc)
+
+    for pb in AIA_EUV_PASSBANDS + AIA_UV_PASSBANDS:
+        key = f"AIA_{pb}"
+        if key in maps:
+            add_refmap(key, maps[key])
+
+    obs_dr = (cfg.dx_km * u.km) / rsun
+    dr3 = np.array([obs_dr.value, obs_dr.value, obs_dr.value])
+    empty_grid = np.zeros((box_dims_resolved[0], box_dims_resolved[1], box_dims_resolved[2]), dtype=float)
+    default_grid = {
+        "voxel_id": gx_box2id({"corona": {"bx": empty_grid, "by": empty_grid, "bz": empty_grid, "dr": dr3}}),
+        "dx": float(dr3[0]),
+        "dy": float(dr3[1]),
+        # Keep compact for uniform-grid models: dz = corona/dr[2].
+        "dz": np.array([float(dr3[2])], dtype=float),
+    }
+
+    out_dir = _stage_output_dir(cfg.gxmodel_dir, obs_time)
+    coord_tag = _format_coord_tag(box_origin.transform_to(HeliographicCarrington(obstime=obs_time)).lon.to_value(u.deg),
+                                  box_origin.transform_to(HeliographicCarrington(obstime=obs_time)).lat.to_value(u.deg))
+    base = _stage_file_base(obs_time, coord_tag, projection_tag=projection_tag)
+    execute_cmd = _build_execute_cmd(cfg)
+
+    produced = []
+    stage_times = {}
+
+    def finalize() -> None:
+        if produced:
+            print("\nCompleted gx-fov2box. Output files:")
+            for path in produced:
+                print(f"- {path}")
+        if stage_times:
+            print("Stage timings:")
+            for stage, seconds in stage_times.items():
+                print(f"- {stage}: {seconds:.2f}s")
+        total = time_mod.perf_counter() - t_start
+        print(f"Total elapsed: {total:.2f}s")
+
+    def save_stage(stage_tag: str, stage_box: dict) -> None:
+        if not _should_save_stage(stage_tag, cfg):
+            return
+        stage_box = dict(stage_box)
+        if "base" not in stage_box:
+            stage_box["base"] = base_group
+        if "refmaps" not in stage_box:
+            stage_box["refmaps"] = refmaps
+        if "grid" not in stage_box:
+            stage_box["grid"] = default_grid
+        stage_id = f"{base}.{stage_tag}"
+        metadata = {
+            "execute": execute_cmd,
+            "id": stage_id,
+            "disambiguation": "SFQ" if cfg.sfq else "HMI",
+            "projection": projection_tag,
+        }
+        if vert_current_error:
+            metadata["vert_current_error"] = vert_current_error
+        stage_box["metadata"] = metadata
+        out_path = _stage_filename(out_dir, base, stage_tag)
+        write_b3d_h5(str(out_path), stage_box)
+        produced.append(out_path)
+
+    if cfg.save_empty_box or cfg.empty_box_only or cfg.stop_after in ("none", "empty", "empty_box"):
+        t0 = time_mod.perf_counter()
+        empty = np.zeros((box_dims_resolved[0], box_dims_resolved[1], box_dims_resolved[2]), dtype=float)
+        stage_box = {"corona": {"bx": empty, "by": empty, "bz": empty, "dr": dr3, "attrs": {"model_type": "none"}}}
+        save_stage("NONE", stage_box)
+        stage_times["NONE"] = time_mod.perf_counter() - t0
+        if cfg.empty_box_only or _last_stage_tag(cfg.stop_after) == "NONE":
+            finalize()
+            return
+
+    if cfg.save_bounds or cfg.stop_after in ("bnd", "bounds"):
+        t0 = time_mod.perf_counter()
+        stage_box = {"bounds": {"bx": bottom_bx.data, "by": bottom_by.data, "bz": bottom_bz.data, "dr": dr3}}
+        save_stage("BND", stage_box)
+        stage_times["BND"] = time_mod.perf_counter() - t0
+        if _last_stage_tag(cfg.stop_after) == "BND":
+            finalize()
+            return
+
+    active_jump = None
+    if cfg.entry_box:
+        if cfg.jump2potential:
+            active_jump = "potential"
+        elif cfg.jump2nlfff:
+            active_jump = "nlfff"
+        elif cfg.jump2lines:
+            active_jump = "lines"
+        elif cfg.jump2chromo:
+            active_jump = "chromo"
+
+    entry_corona = None
+    entry_model = None
+    entry_chromo = None
+    if active_jump:
+        loaded = read_b3d_h5(cfg.entry_box)
+        entry_corona = loaded.get("corona")
+        if entry_corona:
+            entry_model = entry_corona.get("attrs", {}).get("model_type")
+        entry_chromo = loaded.get("chromo")
+
+    goto_lines = active_jump in ("lines", "chromo")
+    goto_chromo = active_jump == "chromo"
+
+    if goto_lines:
+        if not entry_corona or entry_model not in ("pot", "nlfff"):
+            raise ValueError("--jump2lines/--jump2chromo requires --entry-box with corona model_type=pot|nlfff")
+        nlfff_box = entry_corona
+
+    if not goto_lines:
+        if active_jump == "nlfff":
+            if not entry_corona or entry_model not in ("pot", "nlfff"):
+                raise ValueError("--jump2nlfff requires --entry-box with corona model_type=pot|nlfff")
+            pot_box = entry_corona
+        else:
+            t0 = time_mod.perf_counter()
+            bnddata = bottom_bz.data.copy()
+            bnddata[np.isnan(bnddata)] = 0.0
+            maglib_lff = MagFieldLinFFF()
+            maglib_lff.set_field(bnddata)
+            pot_res = maglib_lff.LFFF_cube(nz=box_dims_resolved[2], alpha=0.0)
+            pot_box = {
+                "bx": pot_res["by"].swapaxes(0, 1),
+                "by": pot_res["bx"].swapaxes(0, 1),
+                "bz": pot_res["bz"].swapaxes(0, 1),
+                "dr": dr3,
+                "attrs": {"model_type": "pot"},
+            }
+            save_stage("POT", {"corona": pot_box})
+            stage_times["POT"] = time_mod.perf_counter() - t0
+            if cfg.potential_only or _last_stage_tag(cfg.stop_after) == "POT":
+                finalize()
+                return
+        if cfg.use_potential:
+            nlfff_box = {
+                "bx": pot_box["bx"],
+                "by": pot_box["by"],
+                "bz": pot_box["bz"],
+                "dr": dr3,
+                "attrs": {"model_type": "pot"},
+            }
+        else:
+            t0 = time_mod.perf_counter()
+            maglib = MagFieldProcessor()
+            pot_res = {
+                "bx": pot_box["by"].swapaxes(0, 1),
+                "by": pot_box["bx"].swapaxes(0, 1),
+                "bz": pot_box["bz"].swapaxes(0, 1),
+            }
+            maglib.load_cube_vars(pot_res)
+            res_nlf = maglib.NLFFF()
+            nlfff_box = {
+                "bx": res_nlf["by"].swapaxes(0, 1),
+                "by": res_nlf["bx"].swapaxes(0, 1),
+                "bz": res_nlf["bz"].swapaxes(0, 1),
+                "dr": dr3,
+                "attrs": {"model_type": "nlfff"},
+            }
+            save_stage("NAS", {"corona": nlfff_box})
+            stage_times["NAS"] = time_mod.perf_counter() - t0
+            if cfg.nlfff_only or _last_stage_tag(cfg.stop_after) == "NAS":
+                finalize()
+                return
+
+    if goto_chromo:
+        required_line_keys = [
+            "codes", "apex_idx", "start_idx", "end_idx", "seed_idx",
+            "av_field", "phys_length", "voxel_status",
+        ]
+        if not entry_chromo or any(k not in entry_chromo for k in required_line_keys):
+            raise ValueError("--jump2chromo requires --entry-box containing chromo line metadata (GEN stage).")
+        lines = entry_chromo
+        compute_lines_time = 0.0
+    else:
+        t0 = time_mod.perf_counter()
+        maglib = MagFieldProcessor()
+        maglib.load_cube_vars({
+            "bx": nlfff_box["by"].swapaxes(0, 1),
+            "by": nlfff_box["bx"].swapaxes(0, 1),
+            "bz": nlfff_box["bz"].swapaxes(0, 1),
+        })
+        resolved_reduce_passed = cfg.reduce_passed if cfg.reduce_passed is not None else (0 if cfg.center_vox else 1)
+        lines = maglib.lines(seeds=None, reduce_passed=resolved_reduce_passed)
+        compute_lines_time = time_mod.perf_counter() - t0
+
+    # base_bz/base_ic are prepared above for the base group
+
+    header = _make_header(maps["field"])
+    chromo_box = combo_model(nlfff_box, dr3, base_bz.data.T, base_ic.data.T)
+    for k in ["codes", "apex_idx", "start_idx", "end_idx", "seed_idx",
+              "av_field", "phys_length", "voxel_status"]:
+        chromo_box[k] = lines[k]
+    chromo_box["phys_length"] *= dr3[0]
+    chromo_box["attrs"] = header
+
+    if not goto_chromo:
+        gen_chromo = _make_gen_chromo(chromo_box)
+        save_stage("NAS.GEN", {"chromo": gen_chromo})
+        stage_times["NAS.GEN"] = compute_lines_time
+        if cfg.generic_only or _last_stage_tag(cfg.stop_after) == "NAS.GEN":
+            finalize()
+            return
+
+    t0 = time_mod.perf_counter()
+    chr_grid = {
+        "voxel_id": gx_box2id({"corona": nlfff_box, "chromo": chromo_box}),
+        "dx": float(dr3[0]),
+        "dy": float(dr3[1]),
+        "dz": chromo_box["dz"] if "dz" in chromo_box else dr3,
+    }
+    save_stage("NAS.CHR", {"chromo": chromo_box, "grid": chr_grid})
+    stage_times["NAS.CHR"] = time_mod.perf_counter() - t0
+
+    finalize()
+
+
+if __name__ == "__main__":
+    app()

--- a/pyampp/gxbox/gx_voxelid.py
+++ b/pyampp/gxbox/gx_voxelid.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def gx_voxelid(
+    test_id: int | np.ndarray | None = None,
+    *,
+    chromo: bool = False,
+    tr: bool = False,
+    corona: bool = False,
+    euvtr: bool = False,
+    in_: bool = False,
+    nw: bool = False,
+    enw: bool = False,
+    fa: bool = False,
+    pl: bool = False,
+    pen: bool = False,
+    umb: bool = False,
+    tube: bool = False,
+    layer: bool = False,
+    mask: bool = False,
+) -> np.uint32 | np.ndarray:
+    """IDL-equivalent voxel bitmask builder/tester.
+
+    Port of ``gx_voxelid.pro`` from GX Simulator.
+
+    If ``test_id`` is provided, returns ``id & uint32(test_id)``.
+    Otherwise returns the constructed uint32 ``id``.
+    """
+    vid = np.uint32(0)
+
+    if chromo:
+        vid += np.uint32(1)
+    if tr:
+        vid += np.uint32(2)
+    if corona:
+        vid += np.uint32(4)
+    if euvtr:
+        vid += np.uint32(8)
+
+    if tube:
+        vid += np.uint32(255 << 8)
+    if layer:
+        vid += np.uint32(255 << 16)
+    if mask:
+        vid += np.uint32(255 << 24)
+
+    if in_:
+        vid += np.uint32(1 << 24)
+    if nw:
+        vid += np.uint32(2 << 24)
+    if enw:
+        vid += np.uint32(3 << 24)
+    if fa:
+        vid += np.uint32(4 << 24)
+    if pl:
+        vid += np.uint32(5 << 24)
+    if pen:
+        vid += np.uint32(6 << 24)
+    if umb:
+        vid += np.uint32(7 << 24)
+
+    if test_id is None:
+        return vid
+    return vid & np.asarray(test_id, dtype=np.uint32)
+

--- a/pyampp/gxbox/gxampp.py
+++ b/pyampp/gxbox/gxampp.py
@@ -1,24 +1,28 @@
 import sys
 import os
+import select
+import re
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QLabel, QLineEdit, QPushButton, QComboBox,
                              QRadioButton,
-                             QCheckBox, QGridLayout, QGroupBox, QVBoxLayout, QHBoxLayout, QDateTimeEdit,
-                             QCalendarWidget, QTextEdit, QMessageBox,
+                             QCheckBox, QGridLayout, QGroupBox, QButtonGroup, QVBoxLayout, QHBoxLayout, QDateTimeEdit,
+                             QCalendarWidget, QTextEdit, QMessageBox, QDockWidget, QToolButton, QMenu,
                              QFileDialog)
 from PyQt5.QtGui import QIcon, QFont
-from PyQt5.QtCore import QSize, QDateTime, Qt
+from PyQt5.QtCore import QSize, QDateTime, Qt, QTimer
 from PyQt5 import uic
 
 from pyampp.util.config import *
 import pyampp
 from pathlib import Path
-from pyampp.gxbox.boxutils import validate_number
+from pyampp.gxbox.boxutils import read_b3d_h5, validate_number
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.time import Time
 from sunpy.coordinates import get_earth, HeliographicStonyhurst, HeliographicCarrington, Helioprojective
+from sunpy.sun import constants as sun_consts
 import numpy as np
 import typer
+import subprocess
 
 app = typer.Typer(help="Launch the PyAmpp application.")
 
@@ -103,6 +107,13 @@ class PyAmppGUI(QMainWindow):
         Initializes the PyAmppGUI class.
         """
         super().__init__()
+        self._gxbox_proc = None
+        self._proc_partial_line = ""
+        self.info_only_box = None
+        self._last_model_path = None
+        self._proc_timer = QTimer(self)
+        self._proc_timer.setInterval(500)
+        self._proc_timer.timeout.connect(self._check_gxbox_process)
         self.model_time_orig = None
         # self.rotate_to_time_button = None
         self.rotate_revert_button = None
@@ -116,6 +127,7 @@ class PyAmppGUI(QMainWindow):
         """
         # Main widget and layout
         uic.loadUi(Path(__file__).parent / "UI" / "gxampp.ui", self)
+        self.setWindowTitle("GX Automatic Production Pipeline Interface")
 
         # Adding different sections
         self.add_data_repository_section()
@@ -138,6 +150,10 @@ class PyAmppGUI(QMainWindow):
         self.gx_model_edit.returnPressed.connect(self.update_gxmodel_dir)
         self.gx_browse_button.clicked.connect(self.open_gx_file_dialog)
 
+        notify_email = os.environ.get("PYAMPP_JSOC_NOTIFY_EMAIL", JSOC_NOTIFY_EMAIL)
+        self.jsoc_notify_email_edit.setText(notify_email)
+        self.jsoc_notify_email_edit.returnPressed.connect(self.update_jsoc_notify_email)
+
         self.external_box_edit.returnPressed.connect(self.update_external_box_dir)
         self.external_browse_button.clicked.connect(self.open_external_file_dialog)
 
@@ -157,6 +173,17 @@ class PyAmppGUI(QMainWindow):
         self.update_dir(new_path, GXMODEL_DIR)
         self.update_command_display()
 
+    def update_jsoc_notify_email(self):
+        """
+        Updates the JSOC notify email via the PYAMPP_JSOC_NOTIFY_EMAIL environment variable.
+        """
+        new_email = self.jsoc_notify_email_edit.text().strip()
+        if new_email:
+            os.environ["PYAMPP_JSOC_NOTIFY_EMAIL"] = new_email
+        else:
+            os.environ.pop("PYAMPP_JSOC_NOTIFY_EMAIL", None)
+            self.jsoc_notify_email_edit.setText(JSOC_NOTIFY_EMAIL)
+
     def read_external_box(self):
         """
         Reads the external box path based on the user input.
@@ -164,11 +191,30 @@ class PyAmppGUI(QMainWindow):
         import pickle
 
         boxfile = self.external_box_edit.text()
+        if boxfile.endswith('.h5'):
+            boxdata = read_b3d_h5(boxfile)
+            corona = boxdata.get("corona")
+            if corona and "bx" in corona:
+                nx, ny, nz = corona["bx"].shape
+                self.grid_x_edit.setText(f'{nx}')
+                self.grid_y_edit.setText(f'{ny}')
+                self.grid_z_edit.setText(f'{nz}')
+            if corona and "dr" in corona:
+                dr0 = float(corona["dr"][0])
+                rsun_km = sun_consts.radius.to(u.km).value
+                self.res_edit.setText(f'{dr0 * rsun_km:.3f}')
+            self.update_command_display()
+            return
+
         with open(boxfile, 'rb') as f:
             boxdata = pickle.load(f)
             map_bottom = boxdata['map_bottom']
             self.model_time_orig = map_bottom.date
-            nx, ny, nz = boxdata['b3d']['nlfff']['bx'].shape
+            if "corona" in boxdata.get("b3d", {}):
+                bx = boxdata['b3d']['corona']['bx']
+            else:
+                bx = boxdata['b3d']['nlfff']['bx']
+            nx, ny, nz = bx.shape
             box_res = map_bottom.rsun_meters.to(u.Mm) * ((map_bottom.scale[0] * 1. * u.pix).to(u.rad) / u.rad)
             center = map_bottom.center.transform_to(
                 HeliographicStonyhurst(obstime=self.model_time_orig))
@@ -255,14 +301,34 @@ class PyAmppGUI(QMainWindow):
         """
         options = QFileDialog.Options()
         options |= QFileDialog.DontUseNativeDialog
-        file_name, _ = QFileDialog.getOpenFileName(self, "Select File", os.getcwd(), "gxbox Files (*.gxbox)")
+        file_name, _ = QFileDialog.getOpenFileName(self, "Select File", os.getcwd(), "Model Files (*.h5 *.gxbox)")
         # file_name = QFileDialog.getExistingDirectory(self, "Select Directory", os.getcwd())
         if file_name:
             self.external_box_edit.setText(file_name)
             self.read_external_box()
 
     def add_model_configuration_section(self):
-        self.jump_to_action_combo.addItems(['none', 'potential', 'NLFFF', 'lines', 'chromo'])
+        # Replace combo with radio style jump controls (IDL-like UX).
+        self.jump_to_action_combo.setVisible(False)
+        self.label_jumpToAction.setText("Jump-to Action")
+        self.jump_none_radio = QRadioButton("none")
+        self.jump_potential_radio = QRadioButton("potential")
+        self.jump_nlfff_radio = QRadioButton("nlfff")
+        self.jump_lines_radio = QRadioButton("lines")
+        self.jump_chromo_radio = QRadioButton("chromo")
+        self.jump_none_radio.setChecked(True)
+        self.jump_button_group = QButtonGroup(self)
+        for rb in [
+            self.jump_none_radio,
+            self.jump_potential_radio,
+            self.jump_nlfff_radio,
+            self.jump_lines_radio,
+            self.jump_chromo_radio,
+        ]:
+            self.jump_button_group.addButton(rb)
+            insert_idx = max(0, self.jumpToActionLayout.count() - 1)
+            self.jumpToActionLayout.insertWidget(insert_idx, rb)
+            rb.toggled.connect(self._sync_pipeline_options)
         self.model_time_edit.setDateTime(QDateTime.currentDateTimeUtc())
         self.model_time_edit.setDateTimeRange(QDateTime(2010, 1, 1, 0, 0, 0), QDateTime(QDateTime.currentDateTimeUtc()))
         self.model_time_edit.dateTimeChanged.connect(self.on_time_input_changed)
@@ -280,33 +346,352 @@ class PyAmppGUI(QMainWindow):
         self.res_edit.returnPressed.connect(lambda: self.on_res_input_return_pressed(self.res_edit))
         self.padding_size_edit.returnPressed.connect(
             lambda: self.on_padding_size_input_return_pressed(self.padding_size_edit))
+        self.hpc_radio_button.setText("Heliocentric")
+        self.hgc_radio_button.setText("Carrington")
+        self.hgs_radio_button.setText("Stonyhurst")
+
+        self.proj_group = QGroupBox("Geometrical Projection")
+        self.proj_cea_radio = QRadioButton("CEA")
+        self.proj_top_radio = QRadioButton("TOP")
+        self.proj_cea_radio.setChecked(True)
+        self.proj_button_group = QButtonGroup(self.proj_group)
+        self.proj_button_group.addButton(self.proj_cea_radio)
+        self.proj_button_group.addButton(self.proj_top_radio)
+        proj_layout = QHBoxLayout()
+        proj_layout.addWidget(self.proj_cea_radio)
+        proj_layout.addWidget(self.proj_top_radio)
+        proj_layout.addStretch()
+        self.proj_group.setLayout(proj_layout)
+        self.verticalLayout_2.addWidget(self.proj_group)
+        self.proj_cea_radio.toggled.connect(self.update_command_display)
+        self.proj_top_radio.toggled.connect(self.update_command_display)
+
+        # Standalone disambiguation group in model configuration (not part of workflow options).
+        self.disambig_group = QGroupBox("Pi-disambiguation")
+        self.disambig_hmi_radio = QRadioButton("HMI")
+        self.disambig_sfq_radio = QRadioButton("SFQ")
+        self.disambig_hmi_radio.setChecked(True)
+        self.disambig_button_group = QButtonGroup(self.disambig_group)
+        self.disambig_button_group.addButton(self.disambig_hmi_radio)
+        self.disambig_button_group.addButton(self.disambig_sfq_radio)
+        disambig_layout = QHBoxLayout()
+        disambig_layout.addWidget(self.disambig_hmi_radio)
+        disambig_layout.addWidget(self.disambig_sfq_radio)
+        disambig_layout.addStretch()
+        self.disambig_group.setLayout(disambig_layout)
+        self.verticalLayout_2.addWidget(self.disambig_group)
+        self.disambig_hmi_radio.toggled.connect(self.update_command_display)
+        self.disambig_sfq_radio.toggled.connect(self.update_command_display)
+
+    def _get_jump_action(self):
+        if self.jump_potential_radio.isChecked():
+            return "potential"
+        if self.jump_nlfff_radio.isChecked():
+            return "nlfff"
+        if self.jump_lines_radio.isChecked():
+            return "lines"
+        if self.jump_chromo_radio.isChecked():
+            return "chromo"
+        return "none"
+
+    def _set_jump_action(self, action):
+        target = (action or "none").lower()
+        mapping = {
+            "none": self.jump_none_radio,
+            "potential": self.jump_potential_radio,
+            "nlfff": self.jump_nlfff_radio,
+            "lines": self.jump_lines_radio,
+            "chromo": self.jump_chromo_radio,
+        }
+        rb = mapping.get(target, self.jump_none_radio)
+        rb.blockSignals(True)
+        rb.setChecked(True)
+        rb.blockSignals(False)
 
     def add_options_section(self):
         """
         Adds the options section to the main layout.
         """
-        pass
+        self.optionsGroupBox.setTitle("Pipeline Workflow")
+        self.download_aia_euv.setChecked(True)
+        self.download_aia_uv.setChecked(True)
+        self.save_empty_box.setChecked(False)
+        self.save_potential_box.setChecked(False)
+        self.save_bounds_box.setChecked(False)
+        self.skip_nlfff_extrapolation.setChecked(False)
+        self.stop_after_potential_box.setChecked(False)
+        self.stop_after_potential_box.setVisible(True)
+        self.stop_after_potential_box.setEnabled(True)
+        self.stop_after_potential_box.setText("Stop after the potential box is generated")
+        self.skip_nlfff_extrapolation.setText("Skip NLFFF extrapolation")
+        self.download_aia_uv.setText("Download AIA/UV contextual maps")
+        self.download_aia_euv.setText("Download AIA/EUV contextual maps")
+        self.save_empty_box.setText("Save Empty Box")
+        self.save_potential_box.setText("Save Potential Box")
+        self.save_bounds_box.setText("Save Bounds Box")
+
+        # Additional CLI parity controls (added programmatically to preserve .ui compatibility)
+        options_layout = self.optionsGroupBox.layout()
+        while options_layout.count():
+            item = options_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.setParent(None)
+
+        self.save_nas_box = QCheckBox("Save NAS")
+        self.save_gen_box = QCheckBox("Save GEN")
+        self.save_chr_box = QCheckBox("Save CHR")
+        self.empty_box_only_box = QCheckBox("Empty Box Only")
+        self.potential_only_box = QCheckBox("Potential Only")
+        self.nlfff_only_box = QCheckBox("Stop after the NLFFF box is generated")
+        self.generic_only_box = QCheckBox("Do not add Fontenla chromosphere model")
+        self.center_vox_box = QCheckBox("Center voxel magnetic field line tracing")
+
+        # Match legacy GX two-column workflow layout.
+        options_layout.addWidget(self.download_aia_uv, 0, 0)
+        options_layout.addWidget(self.download_aia_euv, 1, 0)
+        options_layout.addWidget(self.save_empty_box, 2, 0)
+        options_layout.addWidget(self.save_potential_box, 3, 0)
+        options_layout.addWidget(self.save_bounds_box, 4, 0)
+        options_layout.addWidget(self.stop_after_potential_box, 0, 1)
+        options_layout.addWidget(self.skip_nlfff_extrapolation, 1, 1)
+        options_layout.addWidget(self.nlfff_only_box, 2, 1)
+        options_layout.addWidget(self.center_vox_box, 3, 1)
+        options_layout.addWidget(self.generic_only_box, 4, 1)
+
+        # Keep these available for CLI parity but out of this legacy-like workflow layout.
+        self.save_nas_box.setVisible(False)
+        self.save_gen_box.setVisible(False)
+        self.save_chr_box.setVisible(False)
+        self.empty_box_only_box.setVisible(False)
+        self.potential_only_box.setVisible(False)
+
+        # Update command/state when options change
+        dynamic_widgets = [
+            self.download_aia_euv,
+            self.download_aia_uv,
+            self.save_empty_box,
+            self.save_potential_box,
+            self.save_bounds_box,
+            self.stop_after_potential_box,
+            self.skip_nlfff_extrapolation,
+            self.save_nas_box,
+            self.save_gen_box,
+            self.save_chr_box,
+            self.nlfff_only_box,
+            self.generic_only_box,
+            self.center_vox_box,
+        ]
+        for w in dynamic_widgets:
+            w.toggled.connect(self._sync_pipeline_options)
+        self.external_box_edit.textChanged.connect(self.update_command_display)
+        self.sdo_data_edit.textChanged.connect(self.update_command_display)
+        self.gx_model_edit.textChanged.connect(self.update_command_display)
+        self._sync_pipeline_options()
+
+    def _set_checkbox_state(self, box, enabled):
+        box.blockSignals(True)
+        if not enabled and box.isChecked():
+            box.setChecked(False)
+        box.setEnabled(enabled)
+        box.blockSignals(False)
+
+    def _sync_pipeline_options(self, *_):
+        """
+        Enforce linear pipeline behavior:
+        - jump disables controls for preceding stages
+        - *only disables controls for following stages
+        - use-potential disables NAS-stage controls
+        """
+        jump_stage_map = {
+            "none": None,
+            "potential": 1,
+            "nlfff": 3,
+            "lines": 4,
+            "chromo": 5,
+        }
+        save_stage_boxes = [
+            (self.save_empty_box, 0),
+            (self.save_potential_box, 1),
+            (self.save_bounds_box, 2),
+            (self.save_nas_box, 3),
+            (self.save_gen_box, 4),
+            (self.save_chr_box, 5),
+        ]
+        only_stage_boxes = [
+            (self.stop_after_potential_box, 2),
+            (self.nlfff_only_box, 3),
+            (self.generic_only_box, 4),
+        ]
+
+        jump_action = self._get_jump_action()
+        jump_stage = jump_stage_map.get(jump_action)
+
+        # --use-potential means NAS stage is skipped.
+        if self.skip_nlfff_extrapolation.isChecked() and jump_action == "nlfff":
+            self._set_jump_action("lines")
+            jump_action = "lines"
+            jump_stage = 4
+
+        use_potential = self.skip_nlfff_extrapolation.isChecked()
+
+        # Disable NLFFF jump target when NAS is skipped.
+        self.jump_nlfff_radio.setEnabled(not use_potential)
+
+        def only_allowed(stage):
+            if jump_stage is not None and stage < jump_stage:
+                return False
+            if use_potential and stage == 3:
+                return False
+            return True
+
+        # Clear checked *only options that are no longer allowed.
+        for box, stage in only_stage_boxes:
+            if box.isChecked() and not only_allowed(stage):
+                box.blockSignals(True)
+                box.setChecked(False)
+                box.blockSignals(False)
+
+        stop_stage = None
+        for box, stage in only_stage_boxes:
+            if box.isChecked():
+                stop_stage = stage
+                break
+
+        # --use-potential is irrelevant when stop is before NAS.
+        skip_enabled = stop_stage is None or stop_stage >= 3
+        self._set_checkbox_state(self.skip_nlfff_extrapolation, skip_enabled)
+        use_potential = self.skip_nlfff_extrapolation.isChecked()
+
+        # Stops constrain allowable jump destinations too.
+        jump_option_stage = [
+            (self.jump_none_radio, None),
+            (self.jump_potential_radio, 1),
+            (self.jump_lines_radio, 4),
+            (self.jump_chromo_radio, 5),
+        ]
+        for rb, stage in jump_option_stage:
+            enabled = True
+            if stage is not None and stop_stage is not None and stage > stop_stage:
+                enabled = False
+            if stage == 3 and use_potential:
+                enabled = False
+            rb.setEnabled(enabled)
+        self.jump_nlfff_radio.setEnabled(not use_potential and not (stop_stage is not None and 3 > stop_stage))
+
+        selected_jump = self._get_jump_action()
+        selected_stage = {"none": None, "potential": 1, "nlfff": 3, "lines": 4, "chromo": 5}.get(selected_jump)
+        invalid_selected = False
+        if selected_jump == "nlfff":
+            invalid_selected = use_potential or (stop_stage is not None and 3 > stop_stage)
+        elif selected_stage is not None:
+            invalid_selected = stop_stage is not None and selected_stage > stop_stage
+        if invalid_selected:
+            self._set_jump_action("none")
+
+        for box, stage in only_stage_boxes:
+            enabled = only_allowed(stage)
+            if stop_stage is not None and stage > stop_stage:
+                enabled = False
+            self._set_checkbox_state(box, enabled)
+
+        for box, stage in save_stage_boxes:
+            enabled = True
+            if jump_stage is not None and stage < jump_stage:
+                enabled = False
+            if stop_stage is not None and stage > stop_stage:
+                enabled = False
+            if use_potential and stage == 3:
+                enabled = False
+            self._set_checkbox_state(box, enabled)
+
+        # center-vox matters only when lines are computed (stage >= NAS.GEN and not jumping directly to CHR).
+        center_vox_enabled = True
+        if stop_stage is not None and stop_stage < 4:
+            center_vox_enabled = False
+        if jump_stage == 5:
+            center_vox_enabled = False
+        self._set_checkbox_state(self.center_vox_box, center_vox_enabled)
+
+        self.update_command_display()
 
     def add_cmd_display(self):
         """
         Adds the command display section to the main layout.
         """
-        pass
+        mono = QFont("Menlo")
+        mono.setStyleHint(QFont.Monospace)
+        mono.setPointSize(11)
+        self.cmd_display_edit.setFont(mono)
 
     def add_cmd_buttons(self):
         """
         Adds the command buttons to the main layout.
         """
+        self.info_only_box = QCheckBox("Info Only")
+        self.info_only_box.toggled.connect(self.update_command_display)
+        # Place utility toggle with execution controls, not pipeline-flow options.
+        if self.cmd_button_layout is not None:
+            spacer_idx = max(0, self.cmd_button_layout.count() - 1)
+            self.cmd_button_layout.insertWidget(spacer_idx, self.info_only_box)
         self.execute_button.clicked.connect(self.execute_command)
+        self.stop_button.clicked.connect(self.stop_command)
+        self.stop_button.setEnabled(False)
+        self.save_button.setVisible(False)
+        self.save_button.setEnabled(False)
         self.save_button.clicked.connect(self.save_command)
+        self.send_to_viewer_button = QPushButton("Send to gxbox-view")
+        self.send_to_viewer_button.setToolTip("Open latest generated model in gxbox-view")
+        self.send_to_viewer_button.setEnabled(False)
+        if self.cmd_button_layout is not None:
+            spacer_idx = max(0, self.cmd_button_layout.count() - 1)
+            self.cmd_button_layout.insertWidget(spacer_idx, self.send_to_viewer_button)
+        self.send_to_viewer_button.clicked.connect(self.send_to_gxbox_view)
         self.clear_button_refresh.clicked.connect(self.refresh_command)
+        self.clear_button_clear.setVisible(False)
+        self.clear_button_clear.setEnabled(False)
         self.clear_button_clear.clicked.connect(self.clear_command)
 
     def add_status_log(self):
         """
         Adds the status log section to the main layout.
         """
-        pass
+        mono = QFont("Menlo")
+        mono.setStyleHint(QFont.Monospace)
+        mono.setPointSize(10)
+        self.status_log_edit.setFont(mono)
+        # Move console to a right-side dock panel to keep the main workflow visible.
+        for i in range(self.main_layout.count()):
+            item = self.main_layout.itemAt(i)
+            if item is not None and item.widget() is self.status_log_edit:
+                self.main_layout.takeAt(i)
+                break
+        self.console_dock = QDockWidget("Console", self)
+        self.console_dock.setObjectName("consoleDock")
+        self.console_dock.setAllowedAreas(Qt.RightDockWidgetArea)
+        self.console_dock.setFeatures(QDockWidget.DockWidgetMovable | QDockWidget.DockWidgetFloatable)
+        self.console_dock.setMinimumWidth(340)
+        self.console_dock.setMaximumWidth(520)
+        self.console_dock.setWidget(self.status_log_edit)
+        title_bar = QWidget(self.console_dock)
+        title_layout = QHBoxLayout(title_bar)
+        title_layout.setContentsMargins(6, 2, 6, 2)
+        title_layout.setSpacing(4)
+        title_label = QLabel("Console", title_bar)
+        title_layout.addWidget(title_label)
+        title_layout.addStretch()
+        self.console_menu_button = QToolButton(title_bar)
+        self.console_menu_button.setText("⋮")
+        self.console_menu_button.setToolTip("Console options")
+        self.console_menu_button.setPopupMode(QToolButton.InstantPopup)
+        console_menu = QMenu(self.console_menu_button)
+        console_menu.addAction("Clear", self.clear_console)
+        console_menu.addAction("Copy All", self.copy_console)
+        console_menu.addAction("Save As...", self.save_console)
+        self.console_menu_button.setMenu(console_menu)
+        title_layout.addWidget(self.console_menu_button)
+        self.console_dock.setTitleBarWidget(title_bar)
+        self.addDockWidget(Qt.RightDockWidgetArea, self.console_dock)
 
     @validate_number
     def on_coord_x_input_return_pressed(self, widget):
@@ -531,7 +916,7 @@ class PyAmppGUI(QMainWindow):
         import astropy.time
         import astropy.units as u
 
-        command = ['gxbox']
+        command = ['gx-fov2box']
         time = astropy.time.Time(self.model_time_edit.dateTime().toPyDateTime())
         command += ['--time', time.to_datetime().strftime('%Y-%m-%dT%H:%M:%S')]
         command += ['--coords', self.coord_x_edit.text(), self.coord_y_edit.text()]
@@ -541,25 +926,175 @@ class PyAmppGUI(QMainWindow):
             command += ['--hgc']
         else:
             command += ['--hgs']
+        if self.proj_top_radio.isChecked():
+            command += ['--top']
+        else:
+            command += ['--cea']
 
         command += ['--box-dims', self.grid_x_edit.text(), self.grid_y_edit.text(), self.grid_z_edit.text()]
-        command += ['--box-res', f'{((float(self.res_edit.text()) * u.km).to(u.Mm)).value:.3f}']
+        command += ['--dx-km', f'{float(self.res_edit.text()):.3f}']
         command += ['--pad-frac', f'{float(self.padding_size_edit.text()) / 100:.2f}']
         command += ['--data-dir', self.sdo_data_edit.text()]
         command += ['--gxmodel-dir', self.gx_model_edit.text()]
         if self.external_box_edit.text() != '':
-            command += ['--external-box', self.external_box_edit.text()]
-        # print(command)
+            command += ['--entry-box', self.external_box_edit.text()]
+
+        command += ['--euv' if self.download_aia_euv.isChecked() else '--no-euv']
+        command += ['--uv' if self.download_aia_uv.isChecked() else '--no-uv']
+
+        if self.save_empty_box.isChecked():
+            command += ['--save-empty-box']
+        if self.save_potential_box.isChecked():
+            command += ['--save-potential']
+        if self.save_bounds_box.isChecked():
+            command += ['--save-bounds']
+        if self.save_nas_box.isChecked():
+            command += ['--save-nas']
+        if self.save_gen_box.isChecked():
+            command += ['--save-gen']
+        if self.save_chr_box.isChecked():
+            command += ['--save-chr']
+
+        if self.empty_box_only_box.isChecked():
+            command += ['--empty-box-only']
+        if self.stop_after_potential_box.isChecked():
+            command += ['--potential-only']
+        if self.nlfff_only_box.isChecked():
+            command += ['--nlfff-only']
+        if self.generic_only_box.isChecked():
+            command += ['--generic-only']
+
+        if self.skip_nlfff_extrapolation.isChecked():
+            command += ['--use-potential']
+        if self.center_vox_box.isChecked():
+            command += ['--center-vox']
+
+        jump_action = self._get_jump_action()
+        if jump_action == 'potential':
+            command += ['--jump2potential']
+        elif jump_action == 'nlfff':
+            command += ['--jump2nlfff']
+        elif jump_action == 'lines':
+            command += ['--jump2lines']
+        elif jump_action == 'chromo':
+            command += ['--jump2chromo']
+
+        if self.disambig_sfq_radio.isChecked():
+            command += ['--sfq']
+
+        if self.info_only_box is not None and self.info_only_box.isChecked():
+            command += ['--info']
+
         return command
 
     def execute_command(self):
         """
         Executes the constructed command.
         """
-        self.status_log_edit.append("Command executed")
-        import subprocess
+        if self._gxbox_proc is not None and self._gxbox_proc.poll() is None:
+            QMessageBox.warning(self, "GXbox Running", "A GXbox process is already running.")
+            return
+
         command = self.get_command()
-        subprocess.run(command, check=True)
+        self._last_model_path = None
+        self.send_to_viewer_button.setEnabled(False)
+        try:
+            self._gxbox_proc = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                env={**os.environ, "PYTHONUNBUFFERED": "1"},
+            )
+            self._proc_partial_line = ""
+            if self._gxbox_proc.stdout is not None:
+                os.set_blocking(self._gxbox_proc.stdout.fileno(), False)
+            self.execute_button.setEnabled(False)
+            self.stop_button.setEnabled(True)
+            self.status_log_edit.append("Command started: " + " ".join(command))
+            self._proc_timer.start()
+        except Exception as e:
+            QMessageBox.critical(self, "Execution Error", f"Failed to start command: {e}")
+            self.status_log_edit.append("Command failed to start")
+
+    def _drain_process_output(self):
+        if self._gxbox_proc is None or self._gxbox_proc.stdout is None:
+            return
+        stdout = self._gxbox_proc.stdout
+        fd = stdout.fileno()
+        chunks = []
+        while True:
+            ready, _, _ = select.select([fd], [], [], 0)
+            if not ready:
+                break
+            chunk = stdout.read()
+            if not chunk:
+                break
+            chunks.append(chunk)
+        if not chunks:
+            return
+        text = self._proc_partial_line + "".join(chunks).replace("\r\n", "\n").replace("\r", "\n")
+        if text.endswith("\n"):
+            complete_lines = text.split("\n")[:-1]
+            self._proc_partial_line = ""
+        else:
+            parts = text.split("\n")
+            complete_lines = parts[:-1]
+            self._proc_partial_line = parts[-1]
+        for line in complete_lines:
+            if line.strip():
+                self.status_log_edit.append(line)
+
+    def stop_command(self):
+        """
+        Stops the running GXbox process if any.
+        """
+        if self._gxbox_proc is None or self._gxbox_proc.poll() is not None:
+            self.status_log_edit.append("No running command to stop")
+            self.stop_button.setEnabled(False)
+            self.execute_button.setEnabled(True)
+            return
+
+        self.status_log_edit.append("Stopping command...")
+        try:
+            self._gxbox_proc.terminate()
+            self._gxbox_proc.wait(timeout=5)
+            self._drain_process_output()
+            self.status_log_edit.append("Command stopped")
+        except subprocess.TimeoutExpired:
+            self._gxbox_proc.kill()
+            self._drain_process_output()
+            self.status_log_edit.append("Command killed")
+        finally:
+            self._gxbox_proc = None
+            self.stop_button.setEnabled(False)
+            self.execute_button.setEnabled(True)
+            self._proc_timer.stop()
+
+    def _check_gxbox_process(self):
+        if self._gxbox_proc is None:
+            self._proc_timer.stop()
+            return
+
+        self._drain_process_output()
+        if self._gxbox_proc.poll() is None:
+            return
+
+        self._drain_process_output()
+        if self._proc_partial_line.strip():
+            self.status_log_edit.append(self._proc_partial_line)
+            self._proc_partial_line = ""
+        exit_code = self._gxbox_proc.returncode
+        if exit_code == 0:
+            self.status_log_edit.append("Command finished successfully")
+            self._update_last_model_path()
+        else:
+            self.status_log_edit.append(f"Command exited with code {exit_code}")
+        self._gxbox_proc = None
+        self.stop_button.setEnabled(False)
+        self.execute_button.setEnabled(True)
+        self._proc_timer.stop()
 
     def save_command(self):
         """
@@ -581,6 +1116,86 @@ class PyAmppGUI(QMainWindow):
         """
         # Placeholder for clearing command
         self.status_log_edit.clear()
+
+    def clear_console(self):
+        """
+        Clears the console panel.
+        """
+        self.status_log_edit.clear()
+        self._last_model_path = None
+        self.send_to_viewer_button.setEnabled(False)
+
+    def copy_console(self):
+        """
+        Copies the full console text to clipboard.
+        """
+        QApplication.clipboard().setText(self.status_log_edit.toPlainText())
+
+    def save_console(self):
+        """
+        Saves the console output to a text file.
+        """
+        file_name, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save Console Output",
+            str(Path.cwd() / "pyampp_console.txt"),
+            "Text Files (*.txt);;Log Files (*.log);;All Files (*)",
+        )
+        if not file_name:
+            return
+        try:
+            with open(file_name, "w", encoding="utf-8") as f:
+                f.write(self.status_log_edit.toPlainText())
+        except Exception as exc:
+            QMessageBox.critical(self, "Save Failed", f"Could not save console output:\n{exc}")
+
+    def _update_last_model_path(self):
+        text = self.status_log_edit.toPlainText()
+        candidates = re.findall(r"^- (.+\.h5)\s*$", text, flags=re.MULTILINE)
+        for raw in reversed(candidates):
+            p = Path(raw).expanduser()
+            if p.exists():
+                self._last_model_path = str(p)
+                self.send_to_viewer_button.setEnabled(True)
+                return
+        root = Path(self.gx_model_edit.text()).expanduser()
+        if not root.exists():
+            return
+        newest = None
+        newest_mtime = -1.0
+        for p in root.rglob("*.h5"):
+            try:
+                mtime = p.stat().st_mtime
+            except OSError:
+                continue
+            if mtime > newest_mtime:
+                newest_mtime = mtime
+                newest = p
+        if newest is not None:
+            self._last_model_path = str(newest)
+            self.send_to_viewer_button.setEnabled(True)
+
+    def send_to_gxbox_view(self):
+        if not self._last_model_path:
+            QMessageBox.information(self, "No Model", "No generated model was found to send.")
+            return
+        model_path = Path(self._last_model_path).expanduser()
+        if not model_path.exists():
+            QMessageBox.warning(self, "Missing Model", f"Model file not found:\n{model_path}")
+            return
+        try:
+            start_dir = model_path.parent
+            subprocess.Popen([
+                "gxbox-view",
+                "--pick",
+                "--dir",
+                str(start_dir),
+                "--h5",
+                str(model_path),
+            ])
+            self.status_log_edit.append(f"Launched gxbox-view with: {model_path}")
+        except Exception as exc:
+            QMessageBox.critical(self, "Launch Failed", f"Could not launch gxbox-view:\n{exc}")
 
 
 @app.command()

--- a/pyampp/gxbox/gxampp.py
+++ b/pyampp/gxbox/gxampp.py
@@ -530,7 +530,6 @@ class PyAmppGUI(QMainWindow):
         # --use-potential means NAS stage is skipped.
         if self.skip_nlfff_extrapolation.isChecked() and jump_action == "nlfff":
             self._set_jump_action("lines")
-            jump_action = "lines"
             jump_stage = 4
 
         use_potential = self.skip_nlfff_extrapolation.isChecked()

--- a/pyampp/gxbox/gxampp.py
+++ b/pyampp/gxbox/gxampp.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QLabel, QLineEd
                              QCalendarWidget, QTextEdit, QMessageBox, QDockWidget, QToolButton, QMenu,
                              QFileDialog)
 from PyQt5.QtGui import QIcon, QFont
-from PyQt5.QtCore import QSize, QDateTime, Qt, QTimer
+from PyQt5.QtCore import QDateTime, Qt, QTimer
 from PyQt5 import uic
 
 from pyampp.util.config import *

--- a/pyampp/gxbox/gxbox_factory.py
+++ b/pyampp/gxbox/gxbox_factory.py
@@ -14,21 +14,26 @@ from PyQt5 import uic
 
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
+from astropy.io import fits
 from matplotlib import colormaps as mplcmaps
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 from pyAMaFiL.mag_field_proc import MagFieldProcessor
 from pyAMaFiL.mag_field_lin_fff import MagFieldLinFFF
-from sunpy.coordinates import Heliocentric, HeliographicStonyhurst, Helioprojective, get_earth
+from sunpy.coordinates import Heliocentric, HeliographicStonyhurst, HeliographicCarrington, Helioprojective, get_earth
+from sunpy.sun import constants as sun_consts
 from sunpy.map import Map, coordinate_is_on_solar_disk, make_fitswcs_header
 
 import pyampp
 from pyampp.data import downloader
-from pyampp.gxbox.boxutils import hmi_b2ptr, hmi_disambig, read_b3d_h5
+from pyampp.gxbox.box import Box
+from pyampp.gx_chromo.decompose import decompose
+from pyampp.gxbox.boxutils import hmi_b2ptr, hmi_disambig, read_b3d_h5, write_b3d_h5, compute_vertical_current
 from pyampp.gxbox.magfield_viewer import MagFieldViewer
 from pyampp.util.config import *
 
 import typer
+import shlex
 from typing import Tuple, Optional
 
 app = typer.Typer(help="Run GxBox with specified parameters.")
@@ -37,316 +42,87 @@ os.environ['OMP_NUM_THREADS'] = '16'  # number of parallel threads
 locale.setlocale(locale.LC_ALL, "C");
 
 
+def _build_index_header(bottom_wcs_header, source_map: Map) -> str:
+    """
+    Build an IDL-GX compatible INDEX-like FITS header string.
+    """
+    header = fits.Header(bottom_wcs_header).copy()
+
+    ctype1 = str(header.get("CTYPE1", ""))
+    ctype2 = str(header.get("CTYPE2", ""))
+    if ctype1.startswith("HGLN-"):
+        header["CTYPE1"] = "CRLN-" + ctype1.split("-", 1)[1]
+    if ctype2.startswith("HGLT-"):
+        header["CTYPE2"] = "CRLT-" + ctype2.split("-", 1)[1]
+
+    header["SIMPLE"] = int(bool(header.get("SIMPLE", 1)))
+    header["BITPIX"] = int(header.get("BITPIX", 8))
+    header["NAXIS"] = int(header.get("NAXIS", 2))
+
+    if source_map is not None:
+        date_obs = source_map.date.isot if source_map.date is not None else None
+        if date_obs:
+            header["DATE-OBS"] = date_obs
+            header["DATE_OBS"] = date_obs
+            header["DATE"] = date_obs
+        elif "DATE-OBS" in header and "DATE_OBS" not in header:
+            header["DATE_OBS"] = header["DATE-OBS"]
+
+        if hasattr(source_map, "dsun") and source_map.dsun is not None:
+            header["DSUN_OBS"] = float(source_map.dsun.to_value(u.m))
+
+        obs = source_map.observer_coordinate
+        if obs is not None:
+            obs_hgs = obs.transform_to(HeliographicStonyhurst(obstime=source_map.date))
+            header["HGLN_OBS"] = float(obs_hgs.lon.to_value(u.deg))
+            header["HGLT_OBS"] = float(obs_hgs.lat.to_value(u.deg))
+            header["SOLAR_B0"] = float(obs_hgs.lat.to_value(u.deg))
+            try:
+                obs_hgc = obs.transform_to(HeliographicCarrington(observer="earth", obstime=source_map.date))
+                header["CRLN_OBS"] = float(obs_hgc.lon.to_value(u.deg))
+                header["CRLT_OBS"] = float(obs_hgc.lat.to_value(u.deg))
+            except Exception:
+                pass
+
+        if getattr(source_map, "rsun_meters", None) is not None:
+            header["RSUN_REF"] = float(source_map.rsun_meters.to_value(u.m))
+
+        tel = source_map.meta.get("telescop")
+        if tel:
+            header["TELESCOP"] = str(tel)
+        instr = source_map.meta.get("instrume")
+        if instr:
+            header["INSTRUME"] = str(instr)
+        if "WCSNAME" not in header:
+            header["WCSNAME"] = "Carrington-Heliographic"
+
+    return header.tostring(sep="\n", endcard=True)
+
+
 ## todo add chrom mask to the tool
-class Box:
-    """
-    Represents a 3D box in solar or observer coordinates defined by its origin, center, dimensions, and resolution.
-
-    This class calculates and stores the coordinates of the box's edges, differentiating between bottom edges and other edges.
-    It is designed to integrate with solar physics data analysis frameworks such as SunPy and Astropy.
-
-    :param frame_obs: The observer's frame of reference as a `SkyCoord` object.
-    :param box_origin: The origin point of the box in the specified coordinate frame as a `SkyCoord`.
-    :param box_center: The geometric center of the box as a `SkyCoord`.
-    :param box_dims: The dimensions of the box specified as an `astropy.units.Quantity` array-like in the order (x, y, z).
-    :param box_res: The resolution of the box, given as an `astropy.units.Quantity` typically in units of megameters.
-
-    Attributes
-    ----------
-    corners : list of tuple
-        List containing tuples representing the corner points of the box in the specified units.
-    edges : list of tuple
-        List containing tuples that represent the edges of the box by connecting the corners.
-    bottom_edges : list of `SkyCoord`
-        A list containing the bottom edges of the box calculated based on the minimum z-coordinate value.
-    non_bottom_edges : list of `SkyCoord`
-        A list containing all edges of the box that are not classified as bottom edges.
-
-    Methods
-    -------
-    bl_tr_coords(pad_frac=0.0)
-        Calculates and returns the bottom left and top right coordinates of the box in the observer frame.
-        Optionally applies a padding factor to expand the box dimensions symmetrically.
-
-    Example
-    -------
-    >>> from astropy.coordinates import SkyCoord
-    >>> from astropy.time import Time
-    >>> import astropy.units as u
-    >>> time = Time('2024-05-09T17:12:00')
-    >>> box_origin = SkyCoord(450 * u.arcsec, -256 * u.arcsec, obstime=time, observer="earth", frame='helioprojective')
-    >>> box_center = SkyCoord(500 * u.arcsec, -200 * u.arcsec, obstime=time, observer="earth", frame='helioprojective')
-    >>> box_dims = u.Quantity([100, 100, 50], u.Mm)
-    >>> box_res = 1.4 * u.Mm
-    >>> box = Box(frame_obs=box_origin.frame, box_origin=box_origin, box_center=box_center, box_dims=box_dims, box_res=box_res)
-    >>> print(box.bounds_coords_bl_tr())
-    """
-
-    def __init__(self, frame_obs, box_origin, box_center, box_dims, box_res):
-        '''
-        Initializes the Box instance with origin, dimensions, and computes the corners and edges.
-
-        :param box_center: SkyCoord, the origin point of the box in a given coordinate frame.
-        :param box_dims: u.Quantity, the dimensions of the box (x, y, z) in pixel units. x and y are in the solar frame, z is the height above the solar surface.
-        '''
-        self._frame_obs = frame_obs
-        with Helioprojective.assume_spherical_screen(frame_obs.observer):
-            self._origin = box_origin
-            self._center = box_center
-        print(f'box_dims: {box_dims}, box_res: {box_res}')
-        self._dims = box_dims / u.pix * box_res
-        self._res = box_res
-        self._dims_pix = np.int_(box_dims.value)
-        print(f'box_dims_pix: {self._dims_pix}, box_res: {self._res}', '_dims:', self._dims)
-        # Generate corner points based on the dimensions
-        self.corners = list(itertools.product(self._dims[0] / 2 * [-1, 1],
-                                              self._dims[1] / 2 * [-1, 1],
-                                              self._dims[2] / 2 * [-1, 1]))
-
-        # Identify edges as pairs of corners differing by exactly one dimension
-        self.edges = [edge for edge in itertools.combinations(self.corners, 2)
-                      if np.count_nonzero(u.Quantity(edge[0]) - u.Quantity(edge[1])) == 1]
-        # Initialize properties to store categorized edges
-        self._bottom_edges = None
-        self._non_bottom_edges = None
-        self._calculate_edge_types()  # Categorize edges upon initialization
-        self.b3dtype = ['pot', 'nlfff']
-        self.b3d = {b3dtype: None for b3dtype in self.b3dtype}
-
-    @property
-    def dims_pix(self):
-        return self._dims_pix
-
-    @property
-    def grid_coords(self):
-        return self._get_grid_coords(self._center)
-
-    def _get_grid_coords(self, grid_center):
-        grid_coords = {}
-        grid_coords['x'] = np.linspace(grid_center.x.to(self._dims.unit) - self._dims[0] / 2,
-                                       grid_center.x.to(self._dims.unit) + self._dims[0] / 2, self._dims_pix[0])
-        grid_coords['y'] = np.linspace(grid_center.y.to(self._dims.unit) - self._dims[1] / 2,
-                                       grid_center.y.to(self._dims.unit) + self._dims[1] / 2, self._dims_pix[1])
-        grid_coords['z'] = np.linspace(grid_center.z.to(self._dims.unit) - self._dims[2] / 2,
-                                       grid_center.z.to(self._dims.unit) + self._dims[2] / 2, self._dims_pix[2])
-        grid_coords['frame'] = self._frame_obs
-        return grid_coords
-
-    def _get_edge_coords(self, edges, box_center):
-        """
-        Translates edge corner points to their corresponding SkyCoord based on the box's origin.
-
-        :param edges: List of tuples, each tuple contains two corner points defining an edge.
-        :type edges: list of tuple
-        :param box_center: The origin point of the box in the specified coordinate frame as a `SkyCoord`.
-        :type box_center: `~astropy.coordinates.SkyCoord`
-        :return: List of `SkyCoord` coordinates of edges in the box's frame.
-        :rtype: list of `~astropy.coordinates.SkyCoord`
-        """
-        return [SkyCoord(x=box_center.x + u.Quantity([edge[0][0], edge[1][0]]),
-                         y=box_center.y + u.Quantity([edge[0][1], edge[1][1]]),
-                         z=box_center.z + u.Quantity([edge[0][2], edge[1][2]]),
-                         frame=box_center.frame) for edge in edges]
-
-    # def _get_bottom_bl_tr_coords(self,box_center):
-    #     return [SkyCoord(x=box_center.x - self._box_dims[0] / 2,
-    def _get_bottom_cea_header(self):
-        """
-        Generates a CEA header for the bottom of the box.
-
-        :return: The FITS WCS header for the bottom of the box.
-        :rtype: dict
-        """
-        origin = self._origin.transform_to(HeliographicStonyhurst)
-        shape = self._dims[:-1][::-1] / self._res.to(self._dims.unit)
-        shape = list(shape.value)
-        shape = [int(np.ceil(s)) for s in shape]
-        rsun = origin.rsun.to(self._res.unit)
-        scale = np.arcsin(self._res / rsun).to(u.deg) / u.pix
-        scale = u.Quantity((scale, scale))
-        # bottom_cea_header = make_fitswcs_header(shape, origin,
-        #                                         scale=scale, observatory=self._origin.observer, projection_code='CEA')
-        bottom_cea_header = make_fitswcs_header(shape, origin,
-                                                scale=scale, projection_code='CEA')
-        # bottom_cea_header['OBSRVTRY'] = str(origin.observer)
-        bottom_cea_header['OBSRVTRY'] = 'None'
-        return bottom_cea_header
-
-    def _calculate_edge_types(self):
-        """
-        Separates the box's edges into bottom edges and non-bottom edges. This is done in a single pass to improve efficiency.
-        """
-        min_z = min(corner[2] for corner in self.corners)
-        bottom_edges, non_bottom_edges = [], []
-        for edge in self.edges:
-            if edge[0][2] == min_z and edge[1][2] == min_z:
-                bottom_edges.append(edge)
-            else:
-                non_bottom_edges.append(edge)
-        self._bottom_edges = self._get_edge_coords(bottom_edges, self._center)
-        self._non_bottom_edges = self._get_edge_coords(non_bottom_edges, self._center)
-
-    def _get_bounds_coords(self, edges, bltr=False, pad_frac=0.0):
-        """
-        Provides the bounding box of the edges in solar x and y.
-
-        :param edges: List of tuples, each tuple contains two corner points defining an edge.
-        :type edges: list of tuple
-        :param bltr: If True, returns bottom left and top right coordinates, otherwise returns minimum and maximum coordinates.
-        :type bltr: bool, optional
-        :param pad_frac: Fractional padding applied to each side of the box, expressed as a decimal, defaults to 0.0.
-        :type pad_frac: float, optional
-
-        :return: Coordinates of the box's bounds.
-        :rtype: list of `~astropy.coordinates.SkyCoord`
-        """
-        xx = []
-        yy = []
-        for edge in edges:
-            xx.append(edge.transform_to(self._frame_obs).Tx)
-            yy.append(edge.transform_to(self._frame_obs).Ty)
-        unit = xx[0][0].unit
-        min_x = np.min(xx)
-        max_x = np.max(xx)
-        min_y = np.min(yy)
-        max_y = np.max(yy)
-        if pad_frac > 0:
-            _pad = pad_frac * np.max([max_x - min_x, max_y - min_y, 20])
-            min_x -= _pad
-            max_x += _pad
-            min_y -= _pad
-            max_y += _pad
-        if bltr:
-            bottom_left = SkyCoord(min_x * unit, min_y * unit, frame=self._frame_obs)
-            top_right = SkyCoord(max_x * unit, max_y * unit, frame=self._frame_obs)
-            return [bottom_left, top_right]
-        else:
-            coords = SkyCoord(Tx=[min_x, max_x] * unit, Ty=[min_y, max_y] * unit,
-                              frame=self._frame_obs)
-            return coords
-
-    def bounds_coords_bl_tr(self, pad_frac=0.0):
-        """
-        Calculates and returns the bottom left and top right coordinates of the box in the observer frame.
-        Optionally applies a padding factor to expand the box dimensions symmetrically.
-
-        :param pad_frac: Fractional padding applied to each side of the box, expressed as a decimal, defaults to 0.0.
-        :type pad_frac: float, optional
-        :return: Bottom left and top right coordinates of the box in the observer frame.
-        :rtype: list of `~astropy.coordinates.SkyCoord`
-        """
-        return self._get_bounds_coords(self.all_edges, bltr=True, pad_frac=pad_frac)
-
-    @property
-    def bounds_coords(self):
-        """
-        Provides access to the box's bounds in the observer frame.
-
-        :return: Coordinates of the box's bounds.
-        :rtype: `~astropy.coordinates.SkyCoord`
-        """
-        return self._get_bounds_coords(self.all_edges)
-
-    @property
-    def bottom_bounds_coords(self):
-        """
-        Provides access to the box's bottom bounds in the observer frame.
-
-        :return: Coordinates of the box's bottom bounds.
-        :rtype: `~astropy.coordinates.SkyCoord`
-        """
-        return self._get_bounds_coords(self.bottom_edges)
-
-    @property
-    def bottom_cea_header(self):
-        """
-        Provides access to the box's bottom WCS CEA header.
-
-        :return: The WCS CEA header for the box's bottom.
-        :rtype: dict
-        """
-        return self._get_bottom_cea_header()
-
-    @property
-    def bottom_edges(self):
-        """
-        Provides access to the box's bottom edge coordinates.
-
-        :return: Coordinates of the box's bottom edges.
-        :rtype: list of `~astropy.coordinates.SkyCoord`
-        """
-        return self._bottom_edges
-
-    @property
-    def non_bottom_edges(self):
-        """
-        Provides access to the box's non-bottom edge coordinates.
-
-        :return: Coordinates of the box's non-bottom edges.
-        :rtype: list of `~astropy.coordinates.SkyCoord`
-        """
-        return self._non_bottom_edges
-
-    @property
-    def all_edges(self):
-        """
-        Provides access to all the edge coordinates of the box, combining both bottom and non-bottom edges.
-
-        :return: Coordinates of all the edges of the box.
-        :rtype: list of `~astropy.coordinates.SkyCoord`
-        """
-        return self._bottom_edges + self._non_bottom_edges
-
-    @property
-    def box_origin(self):
-        """
-        Provides read-only access to the box's origin coordinates.
-
-        :return: The origin of the box in the specified frame.
-        :rtype: `~astropy.coordinates.SkyCoord`
-        """
-        return self._center
-
-    @property
-    def box_dims(self):
-        """
-        Provides read-only access to the box's dimensions.
-
-        :return: The dimensions of the box (length, width, height) in specified units.
-        :rtype: `~astropy.units.Quantity`
-        """
-        return self._dims
-
-    @property
-    def box_view_up(self):
-        """
-        Retrieves an edge from the bottom edges where the x and z coordinates of both points are the same.
-
-        :return: The edge with the same x and z coordinates.
-        :rtype: `~astropy.coordinates.SkyCoord` or None
-        """
-        for edge in self.bottom_edges:
-            if np.allclose(edge.x[0], edge.x[1]) and np.allclose(edge.z[0], edge.z[1]):
-                return edge
-        return None
-
-    @property
-    def box_norm_direction(self):
-        """
-        Retrieves an edge from the bottom edges where the x and z coordinates of both points are the same.
-
-        :return: The edge with the same x and z coordinates.
-        :rtype: `~astropy.coordinates.SkyCoord` or None
-        """
-        for edge in self.non_bottom_edges:
-            if np.allclose(edge.x[0], edge.x[1]) and np.allclose(edge.y[0], edge.y[1]):
-                return edge
-        return None
-
-
 class GxBox(QMainWindow):
     def __init__(self, time, observer, box_orig, box_dims=u.Quantity([100, 100, 100]) * u.pix,
-                 box_res=1.4 * u.Mm, pad_frac=0.25, data_dir=DOWNLOAD_DIR, gxmodel_dir=GXMODEL_DIR, external_box=None):
+                 box_res=1.4 * u.Mm, pad_frac=0.10, data_dir=DOWNLOAD_DIR, gxmodel_dir=GXMODEL_DIR,
+                 external_box=None, execute_cmd: str | None = None,
+                 save_empty_box: bool = False,
+                 save_bounds: bool = False,
+                 save_potential: bool = False,
+                 save_nas: bool = False,
+                 save_gen: bool = False,
+                 save_chr: bool = False,
+                 stop_after: str | None = None,
+                 auto_visualize_last: bool = True,
+                 euv: bool = True,
+                 uv: bool = True,
+                 hmifiles: str | None = None,
+                 entry_box: str | None = None,
+                 empty_box_only: bool = False,
+                 potential_only: bool = False,
+                 use_potential: bool = False,
+                 jump2potential: bool = False,
+                 jump2nlfff: bool = False,
+                 jump2lines: bool = False,
+                 jump2chromo: bool = False):
         """
         Main application window for visualizing and interacting with solar data in a 3D box.
 
@@ -409,6 +185,29 @@ class GxBox(QMainWindow):
         self.pad_frac = pad_frac
         ## this is the origin of the box, i.e., the center of the box bottom
         self.box_origin = box_orig
+        self.gxmodel_dir = gxmodel_dir
+        self.auto_save_stages = True
+        self.execute_cmd = execute_cmd
+        self.save_empty_box = save_empty_box
+        self.save_bounds = save_bounds
+        self.save_potential = save_potential
+        self.save_nas = save_nas
+        self.save_gen = save_gen
+        self.save_chr = save_chr
+        self.stop_after = stop_after
+        self.auto_visualize_last = auto_visualize_last
+        self.euv = euv
+        self.uv = uv
+        self.hmifiles = hmifiles
+        self.entry_box = entry_box
+        self.empty_box_only = empty_box_only
+        self.potential_only = potential_only
+        self.use_potential = use_potential
+        self.jump2potential = jump2potential
+        self.jump2nlfff = jump2nlfff
+        self.jump2lines = jump2lines
+        self.jump2chromo = jump2chromo
+        self._visualizing_last = False
         self.sdofitsfiles = None
         print('observer:', self.box_origin)
         self.frame_hcc = Heliocentric(observer=self.box_origin, obstime=self.time)
@@ -428,6 +227,237 @@ class GxBox(QMainWindow):
         self.fieldlines_show_status = True  # Initial status of the fieldlines visibility
         self.map_context_im = None
         self.map_bottom_im = None
+        self._base_cache = None
+        self._refmaps_cache = None
+
+    def _stage_output_dir(self) -> Path:
+        date_str = self.time.to_datetime().strftime("%Y-%m-%d")
+        out_dir = Path(self.gxmodel_dir) / date_str
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return out_dir
+
+    def _format_coord_tag(self) -> str:
+        try:
+            coord = self.box_origin.transform_to(HeliographicCarrington(obstime=self.time))
+            suffix = "CR"
+        except Exception:
+            coord = self.box_origin.transform_to(HeliographicStonyhurst(obstime=self.time))
+            suffix = "HG"
+        lon = coord.lon.to_value(u.deg)
+        lat = coord.lat.to_value(u.deg)
+        lon = (lon + 180.0) % 360.0 - 180.0
+        lon_dir = "W" if lon >= 0 else "E"
+        lat_dir = "N" if lat >= 0 else "S"
+        lon_val = f"{abs(int(round(lon))):02d}"
+        lat_val = f"{abs(int(round(lat))):02d}"
+        return f"{lon_dir}{lon_val}{lat_dir}{lat_val}{suffix}"
+
+    def _stage_file_base(self) -> str:
+        time_tag = self.time.to_datetime().strftime("%Y%m%d_%H%M%S")
+        coord_tag = self._format_coord_tag()
+        return f"hmi.M_720s.{time_tag}.{coord_tag}.CEA"
+
+    def _stage_filename(self, stage_tag: str) -> Path:
+        out_dir = self._stage_output_dir()
+        base = self._stage_file_base()
+        return out_dir / f"{base}.{stage_tag}.h5"
+
+    def _make_gen_chromo(self, chromo_box: dict) -> dict:
+        gen_keys = [
+            "dr",
+            "bcube",
+            "start_idx",
+            "end_idx",
+            "av_field",
+            "phys_length",
+            "voxel_status",
+            "apex_idx",
+            "codes",
+            "seed_idx",
+        ]
+        gen = {k: chromo_box[k] for k in gen_keys if k in chromo_box}
+        if "attrs" in chromo_box:
+            gen["attrs"] = chromo_box["attrs"]
+        return gen
+
+    def _last_stage_tag(self) -> str:
+        if self.stop_after:
+            stop = self.stop_after.lower()
+            if stop in ("none", "empty", "empty_box"):
+                return "NONE"
+            if stop in ("bnd", "bounds"):
+                return "BND"
+            if stop == "pot":
+                return "POT"
+            if stop == "nas":
+                return "NAS"
+            if stop == "gen":
+                return "NAS.GEN"
+            if stop == "chr":
+                return "NAS.CHR"
+        return "NAS.CHR"
+
+    def _should_save_stage(self, stage_tag: str) -> bool:
+        if stage_tag == self._last_stage_tag():
+            return True
+        if stage_tag == "POT":
+            return self.save_potential
+        if stage_tag == "NAS":
+            return self.save_nas
+        if stage_tag == "NAS.GEN":
+            return self.save_gen
+        if stage_tag == "NAS.CHR":
+            return self.save_chr
+        if stage_tag == "NONE":
+            return self.save_empty_box
+        if stage_tag == "BND":
+            return self.save_bounds
+        return False
+
+    def _rsun_km(self) -> u.Quantity:
+        rsun = None
+        if self.map_context is not None:
+            rsun = self.map_context.meta.get("rsun_ref")
+        if rsun is None and self.map_bottom is not None:
+            rsun = self.map_bottom.meta.get("rsun_ref")
+        if rsun is not None:
+            return (rsun * u.m).to(u.km)
+        return sun_consts.radius.to(u.km)
+
+    def _open_last_viewer(self, stage_tag: str) -> None:
+        if self._visualizing_last:
+            return
+        self._visualizing_last = True
+        try:
+            if self.box.b3d.get("corona") is None and self.box.b3d.get("chromo") is None:
+                return
+            if stage_tag == "POT":
+                self.b3dModelSelector.setCurrentText("pot")
+                b3dtype = "pot"
+            elif stage_tag in ("NAS", "NAS.GEN"):
+                self.b3dModelSelector.setCurrentText("nlfff")
+                b3dtype = "nlfff"
+            else:
+                b3dtype = "chromo"
+            box_norm_direction = self.box_norm_direction()
+            box_view_up = self.box_view_up()
+            self.visualizer = MagFieldViewer(self.box, parent=self, box_norm_direction=box_norm_direction,
+                                             box_view_up=box_view_up, time=self.time, b3dtype=b3dtype)
+            self.visualizer.show()
+        finally:
+            self._visualizing_last = False
+
+    def _save_empty_box(self) -> None:
+        obs_dr = self.box_res.to(u.km) / self._rsun_km()
+        dr3 = [obs_dr.value, obs_dr.value, obs_dr.value]
+        nx, ny, nz = self.box.dims_pix
+        empty = np.zeros((nx, ny, nz), dtype=float)
+        stage_box = {"corona": {"bx": empty, "by": empty, "bz": empty, "dr": np.array(dr3),
+                                "attrs": {"model_type": "none"}}}
+        self._save_stage("NONE", stage_box)
+
+    def _save_bounds(self) -> None:
+        map_bz = self.loadmap("br")
+        map_bx = -self.loadmap("bt")
+        map_by = self.loadmap("bp")
+        map_bz = map_bz.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+        map_bx = map_bx.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+        map_by = map_by.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+        obs_dr = self.box_res.to(u.km) / self._rsun_km()
+        dr3 = [obs_dr.value, obs_dr.value, obs_dr.value]
+        stage_box = {
+            "bounds": {
+                "bx": map_bx.data,
+                "by": map_by.data,
+                "bz": map_bz.data,
+                "dr": np.array(dr3),
+            }
+        }
+        self._save_stage("BND", stage_box)
+
+    def _get_base_group(self) -> dict:
+        if self._base_cache is not None:
+            return self._base_cache
+        map_bx = -self.loadmap("bt")
+        map_by = self.loadmap("bp")
+        map_bz = self.loadmap("br")
+        map_ic = self.loadmap("continuum")
+        map_bx = map_bx.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+        map_by = map_by.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+        map_bz = map_bz.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+        map_ic = map_ic.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+        index = _build_index_header(self.bottom_wcs_header, map_bz)
+        chromo_mask = decompose(map_bz.data.T, map_ic.data.T)
+        self._base_cache = {
+            "bx": map_bx.data,
+            "by": map_by.data,
+            "bz": map_bz.data,
+            "ic": map_ic.data,
+            "chromo_mask": chromo_mask,
+            "index": index,
+        }
+        return self._base_cache
+
+    def _get_refmaps(self) -> dict:
+        if self._refmaps_cache is not None:
+            return self._refmaps_cache
+        refmaps = {}
+
+        def add_refmap(ref_id: str, smap: Map) -> None:
+            # Use WCS header only to avoid non-ASCII FITS meta from some sources.
+            header = smap.wcs.to_header()
+            refmaps[ref_id] = {"data": smap.data, "wcs_header": header.tostring(sep="\n", endcard=True)}
+
+        add_refmap("Bz_reference", self.loadmap("magnetogram"))
+        add_refmap("Ic_reference", self.loadmap("continuum"))
+
+        vert_current_error = None
+        try:
+            map_bx = -self.loadmap("bt")
+            map_by = self.loadmap("bp")
+            map_bz = self.loadmap("br")
+            vc_header = map_bx.wcs.to_header().tostring(sep="\n", endcard=True)
+            rsun_arcsec = self.loadmap("magnetogram").rsun_obs.to_value(u.arcsec)
+            crpix1, crpix2 = map_bx.wcs.wcs.crpix
+            cdelt1 = map_bx.scale.axis1.to_value(u.arcsec / u.pix)
+            cdelt2 = map_bx.scale.axis2.to_value(u.arcsec / u.pix)
+            jz = compute_vertical_current(map_bz.data, map_bx.data, map_by.data,
+                                          vc_header, rsun_arcsec,
+                                          crpix1=crpix1, crpix2=crpix2,
+                                          cdelt1_arcsec=cdelt1, cdelt2_arcsec=cdelt2)
+            refmaps["Vert_current"] = {"data": jz, "wcs_header": vc_header}
+        except Exception as exc:
+            vert_current_error = str(exc)
+
+        for pb in AIA_EUV_PASSBANDS + AIA_UV_PASSBANDS:
+            if pb in self.sdofitsfiles:
+                add_refmap(f"AIA_{pb}", self.loadmap(pb))
+
+        if vert_current_error:
+            refmaps["_vert_current_error"] = {"data": np.array([vert_current_error]),
+                                               "wcs_header": ""}
+        self._refmaps_cache = refmaps
+        return self._refmaps_cache
+
+    def _save_stage(self, stage_tag: str, stage_box: dict):
+        if not self.auto_save_stages:
+            return
+        if not self._should_save_stage(stage_tag):
+            return
+        out_path = self._stage_filename(stage_tag)
+        stage_box = dict(stage_box)
+        if "base" not in stage_box:
+            stage_box["base"] = self._get_base_group()
+        if "refmaps" not in stage_box:
+            stage_box["refmaps"] = self._get_refmaps()
+        stage_id = f"{self._stage_file_base()}.{stage_tag}"
+        if self.execute_cmd:
+            stage_box["metadata"] = {"execute": self.execute_cmd, "id": stage_id}
+        else:
+            stage_box["metadata"] = {"id": stage_id}
+        write_b3d_h5(str(out_path), stage_box)
+        if self.auto_visualize_last and stage_tag == self._last_stage_tag():
+            self._open_last_viewer(stage_tag)
         self.pot_res = None
 
         box_dimensions = box_dims / u.pix * box_res
@@ -453,7 +483,9 @@ class GxBox(QMainWindow):
         if not all([coordinate_is_on_solar_disk(coord) for coord in self.fov_coords]):
             print("Warning: Some of the box corners are not on the solar disk. Please check the box dimensions.")
 
-        download_sdo = downloader.SDOImageDownloader(time, data_dir=data_dir)
+        if self.hmifiles:
+            data_dir = self.hmifiles
+        download_sdo = downloader.SDOImageDownloader(time, data_dir=data_dir, euv=self.euv, uv=self.uv)
         self.sdofitsfiles = download_sdo.download_images()
         self.sdomaps = {}
 
@@ -467,7 +499,28 @@ class GxBox(QMainWindow):
                                                                                algorithm="adaptive",
                                                                                roundtrip_coords=False)
 
+        if self.save_empty_box:
+            self._save_empty_box()
+        if self.save_bounds:
+            self._save_bounds()
+
         self.init_ui()
+
+        if self.entry_box:
+            if os.path.isfile(self.entry_box):
+                self.load_gxbox(self.entry_box)
+            if self.jump2potential:
+                self.stop_after = "pot"
+                self.calc_potential_field()
+            elif self.jump2nlfff:
+                self.stop_after = "nas"
+                self.calc_nlfff()
+            elif self.jump2lines:
+                self.stop_after = "gen"
+                self.calc_nlfff()
+            elif self.jump2chromo:
+                self.stop_after = "chr"
+                self.calc_nlfff()
 
     def box_norm_direction(self):
         cartesian_coords = self.box_origin.transform_to(
@@ -492,10 +545,23 @@ class GxBox(QMainWindow):
         if os.path.basename(boxfile).endswith('.gxbox'):
             with open(boxfile, 'rb') as f:
                 gxboxdata = pickle.load(f)
-                for b3dtype in self.box.b3dtype:
-                    self.box.b3d[b3dtype] = gxboxdata['b3d'][b3dtype] if b3dtype in gxboxdata['b3d'].keys() else None
+                b3d = gxboxdata.get('b3d', {})
+                if "corona" in b3d:
+                    self.box.b3d["corona"] = b3d["corona"]
+                    self.box.corona_type = b3d.get("corona", {}).get("attrs", {}).get("model_type")
+                elif "nlfff" in b3d or "pot" in b3d:
+                    for model_type in ("nlfff", "pot"):
+                        if model_type in b3d:
+                            self.box.corona_models[model_type] = b3d[model_type]
+                            self.box.b3d["corona"] = b3d[model_type]
+                            self.box.corona_type = model_type
+                            break
         elif os.path.basename(boxfile).endswith('.h5'):
             self.box.b3d = read_b3d_h5(boxfile)
+            if "corona" in self.box.b3d:
+                self.box.corona_type = self.box.b3d["corona"].get("attrs", {}).get("model_type")
+                if self.box.corona_type in ("pot", "nlfff"):
+                    self.box.corona_models[self.box.corona_type] = self.box.b3d["corona"]
         print(self.box.b3d.keys())
 
     @property
@@ -694,20 +760,33 @@ class GxBox(QMainWindow):
         ## the axis order in res is y, x, z. so we need to swap the first two axes, so that the order becomes x, y, z.
         self.pot_res = maglib_lff.LFFF_cube(nz=self.box.dims_pix[-1], alpha=0.0)
         print(f'Time taken to compute potential field solution: {time.time() - t0:.1f} seconds')
-        self.box.b3d['pot'] = {}
-        self.box.b3d['pot']['bx'] = self.pot_res['by'].swapaxes(0, 1)
-        self.box.b3d['pot']['by'] = self.pot_res['bx'].swapaxes(0, 1)
-        self.box.b3d['pot']['bz'] = self.pot_res['bz'].swapaxes(0, 1)
+        obs_dr = self.box._res.to(u.km) / self._rsun_km()
+        dr3 = [obs_dr.value, obs_dr.value, obs_dr.value]
+        pot_box = {
+            "bx": self.pot_res['by'].swapaxes(0, 1),
+            "by": self.pot_res['bx'].swapaxes(0, 1),
+            "bz": self.pot_res['bz'].swapaxes(0, 1),
+            "dr": np.array(dr3),
+            "attrs": {"model_type": "pot"},
+        }
+        self.box.corona_models["pot"] = pot_box
+        self.box.b3d["corona"] = pot_box
+        self.box.corona_type = "pot"
+        self._save_stage("POT", {"corona": pot_box})
+        if self.stop_after and self.stop_after.lower() == "pot":
+            return
 
     def calc_nlfff(self):
         import time
         from pyampp.util.compute import cutout2box
         from pyampp.gx_chromo.combo_model import combo_model
 
-        self.box.b3d['nlfff'] = {}
-        if self.box.b3d['pot'] is None:
+        if "pot" not in self.box.corona_models:
             self.calc_potential_field()
-        bx_lff, by_lff, bz_lff = [self.box.b3d['pot'][k].swapaxes(0, 1) for k in ("by", "bx", "bz")]
+        if self.stop_after and self.stop_after.lower() == "pot":
+            return
+        pot_box = self.box.corona_models["pot"]
+        bx_lff, by_lff, bz_lff = [pot_box[k].swapaxes(0, 1) for k in ("by", "bx", "bz")]
         # replace bottom boundary of lff solution with initial boundary conditions
         bvect_bottom = {}
         bvect_bottom['bz'] = self.sdomaps['br'] if 'br' in self.sdomaps.keys() else self.loadmap('br')
@@ -731,18 +810,45 @@ class GxBox(QMainWindow):
         t0 = time.time()
         maglib = MagFieldProcessor()
         if self.pot_res is None:
-            self.pot_res['bx'] = self.box.b3d['pot']['by'].swapaxes(0, 1)
-            self.pot_res['by'] = self.box.b3d['pot']['bx'].swapaxes(0, 1)
-            self.pot_res['bz'] = self.box.b3d['pot']['bz'].swapaxes(0, 1)
+            self.pot_res = {}
+            self.pot_res['bx'] = pot_box['by'].swapaxes(0, 1)
+            self.pot_res['by'] = pot_box['bx'].swapaxes(0, 1)
+            self.pot_res['bz'] = pot_box['bz'].swapaxes(0, 1)
         maglib.load_cube_vars(self.pot_res)
 
-        res_nlf = maglib.NLFFF()
-        print(f'Time taken to compute NLFFF solution: {time.time() - t0:.1f} seconds')
+        if self.use_potential:
+            bx_nlff, by_nlff, bz_nlff = pot_box["bx"], pot_box["by"], pot_box["bz"]
+            obs_dr = self.box._res.to(u.km) / self._rsun_km()
+            dr3 = [obs_dr.value, obs_dr.value, obs_dr.value]
+            nlfff_box = {
+                "bx": bx_nlff,
+                "by": by_nlff,
+                "bz": bz_nlff,
+                "dr": np.array(dr3),
+                "attrs": {"model_type": "pot"},
+            }
+            self.box.b3d["corona"] = nlfff_box
+            self.box.corona_type = "pot"
+        else:
+            res_nlf = maglib.NLFFF()
+            print(f'Time taken to compute NLFFF solution: {time.time() - t0:.1f} seconds')
 
-        bx_nlff, by_nlff, bz_nlff = [res_nlf[k].swapaxes(0, 1) for k in ("by", "bx", "bz")]
-        self.box.b3d['nlfff']['bx'] = bx_nlff
-        self.box.b3d['nlfff']['by'] = by_nlff
-        self.box.b3d['nlfff']['bz'] = bz_nlff
+            bx_nlff, by_nlff, bz_nlff = [res_nlf[k].swapaxes(0, 1) for k in ("by", "bx", "bz")]
+            obs_dr = self.box._res.to(u.km) / self._rsun_km()
+            dr3 = [obs_dr.value, obs_dr.value, obs_dr.value]
+            nlfff_box = {
+                "bx": bx_nlff,
+                "by": by_nlff,
+                "bz": bz_nlff,
+                "dr": np.array(dr3),
+                "attrs": {"model_type": "nlfff"},
+            }
+            self.box.corona_models["nlfff"] = nlfff_box
+            self.box.b3d["corona"] = nlfff_box
+            self.box.corona_type = "nlfff"
+            self._save_stage("NAS", {"corona": nlfff_box})
+        if self.stop_after and self.stop_after.lower() == "nas":
+            return
 
         t1  = time.time()
         print("Calculating field lines")
@@ -762,17 +868,22 @@ class GxBox(QMainWindow):
         dsun_obs = header_field["DSUN_OBS"]
         header = {"lon": lon, "lat": lat, "dsun_obs": dsun_obs, "obs_time": str(obs_time.iso)}
 
-        obs_dr = self.box._res.to(u.km) / (696000 * u.km)
+        obs_dr = self.box._res.to(u.km) / self._rsun_km()
         dr3 = [obs_dr.value, obs_dr.value, obs_dr.value]
 
-        chromo_box = combo_model(self.box.b3d['nlfff'], dr3, base_bz.data.T, base_ic.data.T)
+        chromo_box = combo_model(self.box.b3d['corona'], dr3, base_bz.data.T, base_ic.data.T)
         for k in ["codes", "apex_idx", "start_idx", "end_idx", "seed_idx",\
                   "av_field", "phys_length", "voxel_status"]:
             chromo_box[k] = lines[k]
         chromo_box["phys_length"] *= dr3[0]
         chromo_box["attrs"] = header
+        gen_chromo = self._make_gen_chromo(chromo_box)
+        self._save_stage("NAS.GEN", {"chromo": gen_chromo})
+        if self.stop_after and self.stop_after.lower() == "gen":
+            return
 
         self.box.b3d["chromo"] = chromo_box
+        self._save_stage("NAS.CHR", {"chromo": self.box.b3d["chromo"]})
         print(f"Time taken to compute chromosphere model: {time.time() - t1:.1f} seconds")
 
     def calc_chromo_model(self):
@@ -790,14 +901,15 @@ class GxBox(QMainWindow):
         # print(f'type of self.box.b3d is {type(self.box.b3d)}')
         # print(f'value of self.box.b3d is {self.box.b3d}')
         # if b3dtype == 'pot':
-        if b3dtype == 'nlfff' and self.box.b3d['nlfff'] is not None:
-            print(f'Using existing nlfff solution...')
+        if self.box.b3d["corona"] is not None and (self.box.corona_type is None or self.box.corona_type == b3dtype):
+            print(f'Using existing {self.box.corona_type or "corona"} solution...')
+        elif b3dtype in self.box.corona_models:
+            self.box.b3d["corona"] = self.box.corona_models[b3dtype]
+            self.box.corona_type = b3dtype
+            print(f'Using existing {b3dtype} solution...')
         else:
             if b3dtype == 'pot':
-                if self.box.b3d['pot'] is None:
-                    self.calc_potential_field()
-                else:
-                    print(f'Using existing potential field solution...')
+                self.calc_potential_field()
             elif b3dtype == 'nlfff':
                 self.calc_nlfff()
 
@@ -1147,13 +1259,13 @@ def _validate_frame(
 
 @app.command()
 def main(
-        time: str = typer.Option(
-            ...,
+        time: Optional[str] = typer.Option(
+            None,
             "--time",
             help='Observation time in ISO format, e.g., "2024-05-12T00:00:00".'
         ),
-        coords: Tuple[float, float] = typer.Option(
-            ...,
+        coords: Optional[Tuple[float, float]] = typer.Option(
+            None,
             "--coords",
             help="Two floats: [x, y] (arcsec if HPC, degrees if HGC or HGS). Example: 0.0 0.0",
         ),
@@ -1172,12 +1284,12 @@ def main(
             "--hgs",
             help="Use Heliographic Stonyhurst coordinates."
         ),
-        box_dims: Tuple[int, int, int] = typer.Option(
+        box_dims: Optional[Tuple[int, int, int]] = typer.Option(
             (100, 100, 100),
             "--box-dims",
             help="Three ints: box dimensions [nx, ny, nz] in pixels. Example: 100 100 100"
         ),
-        box_res: float = typer.Option(
+        box_res: Optional[float] = typer.Option(
             1.4,
             "--box-res",
             help="Box resolution in Mm per pixel."
@@ -1187,22 +1299,22 @@ def main(
             "--observer",
             help="Observer location (e.g., 'earth' or a named object)."
         ),
-        pad_frac: float = typer.Option(
+        pad_frac: Optional[float] = typer.Option(
             0.25,
             "--pad-frac",
             help="Fractional padding applied to each side of the box (decimal)."
         ),
-        data_dir: str = typer.Option(
+        data_dir: Optional[str] = typer.Option(
             DOWNLOAD_DIR,
             "--data-dir",
             help="Directory for storing downloaded data."
         ),
-        gxmodel_dir: str = typer.Option(
+        gxmodel_dir: Optional[str] = typer.Option(
             GXMODEL_DIR,
             "--gxmodel-dir",
             help="Directory for storing model outputs."
         ),
-        external_box: str = typer.Option(
+        external_box: Optional[str] = typer.Option(
             os.path.abspath(os.getcwd()),
             "--external-box",
             help="Path to an external box file."
@@ -1211,6 +1323,106 @@ def main(
             False,
             "--interactive",
             help="Enable interactive mode (drops into pdb after launching)."
+        ),
+        euv: bool = typer.Option(
+            True,
+            "--euv/--no-euv",
+            help="Download AIA/EUV context maps (default: on)."
+        ),
+        uv: bool = typer.Option(
+            True,
+            "--uv/--no-uv",
+            help="Download AIA/UV context maps (default: on)."
+        ),
+        hmifiles: Optional[str] = typer.Option(
+            None,
+            "--hmifiles",
+            help="Path to a local HMI data directory to bypass downloads."
+        ),
+        entry_box: Optional[str] = typer.Option(
+            None,
+            "--entry-box",
+            help="Path to a preexisting box to use as starting point."
+        ),
+        empty_box_only: bool = typer.Option(
+            False,
+            "--empty-box-only",
+            help="Stop after empty box is generated."
+        ),
+        potential_only: bool = typer.Option(
+            False,
+            "--potential-only",
+            help="Compute only the potential extrapolation and stop."
+        ),
+        use_potential: bool = typer.Option(
+            False,
+            "--use-potential",
+            help="Skip NLFFF and use the potential field for downstream steps."
+        ),
+        jump2potential: bool = typer.Option(
+            False,
+            "--jump2potential",
+            help="Start from entry_box and jump to potential stage."
+        ),
+        jump2nlfff: bool = typer.Option(
+            False,
+            "--jump2nlfff",
+            help="Start from entry_box and jump to NLFFF stage."
+        ),
+        jump2lines: bool = typer.Option(
+            False,
+            "--jump2lines",
+            help="Start from entry_box and jump to lines/GEN stage."
+        ),
+        jump2chromo: bool = typer.Option(
+            False,
+            "--jump2chromo",
+            help="Start from entry_box and jump to chromo stage."
+        ),
+        save_empty_box: bool = typer.Option(
+            False,
+            "--save-empty-box",
+            help="Save the empty box stage (NONE)."
+        ),
+        save_bounds: bool = typer.Option(
+            False,
+            "--save-bounds",
+            help="Save the boundary stage (BND)."
+        ),
+        save_potential: bool = typer.Option(
+            False,
+            "--save-potential",
+            help="Save the potential stage (POT)."
+        ),
+        save_nas: bool = typer.Option(
+            False,
+            "--save-nas",
+            help="Save the NLFFF stage (NAS)."
+        ),
+        save_gen: bool = typer.Option(
+            False,
+            "--save-gen",
+            help="Save the GEN stage (NAS.GEN)."
+        ),
+        save_chr: bool = typer.Option(
+            False,
+            "--save-chr",
+            help="Save the CHR stage (NAS.CHR)."
+        ),
+        stop_after: Optional[str] = typer.Option(
+            None,
+            "--stop-after",
+            help="Stop after stage: pot|nas|gen|chr."
+        ),
+        auto_visualize_last: bool = typer.Option(
+            True,
+            "--auto-visualize-last/--no-auto-visualize-last",
+            help="Auto-launch the 3D viewer for the last stage."
+        ),
+        info: bool = typer.Option(
+            False,
+            "--info",
+            help="Print all explicit and implicit options with their meanings and exit."
         ),
 ):
     """
@@ -1262,6 +1474,150 @@ def main(
         --gxmodel-dir /path/to/gx_models_dir
     """
 
+    def _build_execute_cmd() -> str:
+        parts = [
+            "gxbox",
+            "--time",
+            time or "<MISSING_TIME>",
+            "--coords",
+            str(coords[0]) if coords else "<MISSING_X>",
+            str(coords[1]) if coords else "<MISSING_Y>",
+        ]
+        if hpc:
+            parts.append("--hpc")
+        elif hgc:
+            parts.append("--hgc")
+        elif hgs:
+            parts.append("--hgs")
+        parts += [
+            "--box-dims",
+            str(box_dims[0]) if box_dims else "<MISSING_NX>",
+            str(box_dims[1]) if box_dims else "<MISSING_NY>",
+            str(box_dims[2]) if box_dims else "<MISSING_NZ>",
+            "--box-res",
+            str(box_res) if box_res is not None else "<MISSING_BOX_RES>",
+            "--pad-frac",
+            str(pad_frac) if pad_frac is not None else "<MISSING_PAD_FRAC>",
+            "--data-dir",
+            data_dir or "<MISSING_DATA_DIR>",
+            "--gxmodel-dir",
+            gxmodel_dir or "<MISSING_GXMODEL_DIR>",
+            "--observer",
+            observer or "<MISSING_OBSERVER>",
+            "--external-box",
+            external_box or "<MISSING_EXTERNAL_BOX>",
+        ]
+        if interactive:
+            parts.append("--interactive")
+        if not euv:
+            parts.append("--no-euv")
+        if not uv:
+            parts.append("--no-uv")
+        if hmifiles:
+            parts += ["--hmifiles", hmifiles]
+        if entry_box:
+            parts += ["--entry-box", entry_box]
+        if empty_box_only:
+            parts.append("--empty-box-only")
+        if potential_only:
+            parts.append("--potential-only")
+        if use_potential:
+            parts.append("--use-potential")
+        if jump2potential:
+            parts.append("--jump2potential")
+        if jump2nlfff:
+            parts.append("--jump2nlfff")
+        if jump2lines:
+            parts.append("--jump2lines")
+        if jump2chromo:
+            parts.append("--jump2chromo")
+        if save_empty_box:
+            parts.append("--save-empty-box")
+        if save_bounds:
+            parts.append("--save-bounds")
+        if save_potential:
+            parts.append("--save-potential")
+        if save_nas:
+            parts.append("--save-nas")
+        if save_gen:
+            parts.append("--save-gen")
+        if save_chr:
+            parts.append("--save-chr")
+        if stop_after:
+            parts += ["--stop-after", stop_after]
+        if not auto_visualize_last:
+            parts.append("--no-auto-visualize-last")
+        return " ".join(shlex.quote(p) for p in parts)
+
+    def _print_info() -> None:
+        print("gxbox options (explicit and implicit):")
+        print("")
+        time_val = time if time is not None else "<MISSING> (required)"
+        coords_val = f"{coords[0]} {coords[1]}" if coords is not None else "<MISSING> (required)"
+        frame = "--hpc" if hpc else "--hgc" if hgc else "--hgs" if hgs else "<MISSING_FRAME>"
+        box_dims_val = f"{box_dims[0]} {box_dims[1]} {box_dims[2]}" if box_dims else "<MISSING>"
+        print(f"  --time           Observation time in ISO format. [value: {time_val}]")
+        print(f"  --coords         Center coordinates. [value: {coords_val}]")
+        print(f"  {frame:<15} Coordinate frame flag (exactly one of --hpc/--hgc/--hgs).")
+        print(f"  --box-dims       Box dimensions [nx ny nz] in pixels. [value: {box_dims_val}]")
+        print(f"  --box-res        Box resolution in Mm per pixel. [value: {box_res}]")
+        print(f"  --pad-frac       Fractional padding applied to each side. [value: {pad_frac}]")
+        print(f"  --observer       Observer location. [value: {observer}]")
+        print(f"  --data-dir       Directory for downloaded data. [value: {data_dir}]")
+        print(f"  --gxmodel-dir    Directory for model outputs. [value: {gxmodel_dir}]")
+        print(f"  --external-box   Path to an external box file. [value: {external_box}]")
+        print(f"  --interactive    Drop into pdb after launching. [value: {interactive}]")
+        print(f"  --euv            Download AIA/EUV context maps. [value: {euv}]")
+        print(f"  --uv             Download AIA/UV context maps. [value: {uv}]")
+        print(f"  --hmifiles       Local HMI data directory. [value: {hmifiles}]")
+        print(f"  --entry-box      Preexisting box path. [value: {entry_box}]")
+        print(f"  --empty-box-only Stop after empty box is generated. [value: {empty_box_only}]")
+        print(f"  --potential-only Stop after potential extrapolation. [value: {potential_only}]")
+        print(f"  --use-potential  Skip NLFFF and use potential downstream. [value: {use_potential}]")
+        print(f"  --jump2potential Jump to potential stage (requires --entry-box). [value: {jump2potential}]")
+        print(f"  --jump2nlfff     Jump to NLFFF stage (requires --entry-box). [value: {jump2nlfff}]")
+        print(f"  --jump2lines     Jump to GEN stage (requires --entry-box). [value: {jump2lines}]")
+        print(f"  --jump2chromo    Jump to chromo stage (requires --entry-box). [value: {jump2chromo}]")
+        print(f"  --save-empty-box Save NONE stage. [value: {save_empty_box}]")
+        print(f"  --save-bounds    Save BND stage. [value: {save_bounds}]")
+        print(f"  --save-potential Save POT stage. [value: {save_potential}]")
+        print(f"  --save-nas       Save NAS stage. [value: {save_nas}]")
+        print(f"  --save-gen       Save NAS.GEN stage. [value: {save_gen}]")
+        print(f"  --save-chr       Save NAS.CHR stage. [value: {save_chr}]")
+        print(f"  --stop-after     Stop after stage (pot|nas|gen|chr). [value: {stop_after}]")
+        print(f"  --auto-visualize-last Auto-launch 3D viewer for last stage. [value: {auto_visualize_last}]")
+        print("")
+        print("Implicit behaviors:")
+        print("  - Exactly one coordinate frame flag must be set (--hpc/--hgc/--hgs).")
+        if time is None:
+            print("  - WARNING: --time is required for actual execution.")
+        if coords is None:
+            print("  - WARNING: --coords is required for actual execution.")
+        if not (hpc or hgc or hgs):
+            print("  - WARNING: one of --hpc/--hgc/--hgs is required for actual execution.")
+        if (jump2potential or jump2nlfff or jump2lines or jump2chromo) and not entry_box:
+            print("  - WARNING: jump2* flags are ignored unless --entry-box is provided.")
+        print("  - The gxbox GUI launches unless --info is used.")
+        print("  - The last stage is always saved; additional stages depend on save flags.")
+        print("  - The full gxbox command is recorded into HDF5 metadata/execute.")
+
+    if info:
+        _print_info()
+        raise SystemExit(0)
+
+    if time is None:
+        raise typer.BadParameter("--time is required unless --info is used.")
+    if coords is None:
+        raise typer.BadParameter("--coords is required unless --info is used.")
+    if not (hpc or hgc or hgs):
+        raise typer.BadParameter("Exactly one coordinate frame must be specified: use either --hpc, --hgc, or --hgs.")
+    if empty_box_only:
+        save_empty_box = True
+        stop_after = "none"
+    if potential_only:
+        save_potential = True
+        stop_after = "pot"
+
     observation_time = Time(time)
 
     # Determine observer location
@@ -1276,6 +1632,7 @@ def main(
 
     # Instantiate Qt application and GxBox
     app_instance = QApplication([])
+    execute_cmd = _build_execute_cmd()
     gxbox = GxBox(
         observation_time,
         observer_coord,
@@ -1286,6 +1643,26 @@ def main(
         data_dir=data_dir,
         gxmodel_dir=gxmodel_dir,
         external_box=external_box,
+        execute_cmd=execute_cmd,
+        euv=euv,
+        uv=uv,
+        hmifiles=hmifiles,
+        entry_box=entry_box,
+        empty_box_only=empty_box_only,
+        potential_only=potential_only,
+        use_potential=use_potential,
+        jump2potential=jump2potential,
+        jump2nlfff=jump2nlfff,
+        jump2lines=jump2lines,
+        jump2chromo=jump2chromo,
+        save_empty_box=save_empty_box,
+        save_bounds=save_bounds,
+        save_potential=save_potential,
+        save_nas=save_nas,
+        save_gen=save_gen,
+        save_chr=save_chr,
+        stop_after=stop_after,
+        auto_visualize_last=auto_visualize_last,
     )
     gxbox.show()
 

--- a/pyampp/gxbox/gxbox_factory.py
+++ b/pyampp/gxbox/gxbox_factory.py
@@ -82,6 +82,8 @@ def _build_index_header(bottom_wcs_header, source_map: Map) -> str:
                 header["CRLN_OBS"] = float(obs_hgc.lon.to_value(u.deg))
                 header["CRLT_OBS"] = float(obs_hgc.lat.to_value(u.deg))
             except Exception:
+                # Carrington observer transforms can fail for some observer metadata;
+                # keep header generation robust and proceed with available keys.
                 pass
 
         if getattr(source_map, "rsun_meters", None) is not None:
@@ -360,9 +362,9 @@ class GxBox(QMainWindow):
         map_bz = self.loadmap("br")
         map_bx = -self.loadmap("bt")
         map_by = self.loadmap("bp")
-        map_bz = map_bz.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
-        map_bx = map_bx.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
-        map_by = map_by.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+        map_bz = map_bz.reproject_to(self.bottom_wcs_header, algorithm="exact")
+        map_bx = map_bx.reproject_to(self.bottom_wcs_header, algorithm="exact")
+        map_by = map_by.reproject_to(self.bottom_wcs_header, algorithm="exact")
         obs_dr = self.box_res.to(u.km) / self._rsun_km()
         dr3 = [obs_dr.value, obs_dr.value, obs_dr.value]
         stage_box = {
@@ -382,10 +384,10 @@ class GxBox(QMainWindow):
         map_by = self.loadmap("bp")
         map_bz = self.loadmap("br")
         map_ic = self.loadmap("continuum")
-        map_bx = map_bx.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
-        map_by = map_by.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
-        map_bz = map_bz.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
-        map_ic = map_ic.reproject_to(self.bottom_wcs_header, algorithm="adaptive", roundtrip_coords=False)
+        map_bx = map_bx.reproject_to(self.bottom_wcs_header, algorithm="exact")
+        map_by = map_by.reproject_to(self.bottom_wcs_header, algorithm="exact")
+        map_bz = map_bz.reproject_to(self.bottom_wcs_header, algorithm="exact")
+        map_ic = map_ic.reproject_to(self.bottom_wcs_header, algorithm="exact")
         index = _build_index_header(self.bottom_wcs_header, map_bz)
         chromo_mask = decompose(map_bz.data.T, map_ic.data.T)
         self._base_cache = {

--- a/pyampp/gxbox/gxrefmap_view.py
+++ b/pyampp/gxbox/gxrefmap_view.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import h5py
+import numpy as np
+import typer
+from astropy.io import fits
+from PyQt5 import QtWidgets, QtCore
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
+from matplotlib.figure import Figure
+from matplotlib import colors
+import astropy.units as u
+import sunpy.map
+
+app = typer.Typer(help="View refmaps and base maps stored in a model HDF5 file.")
+
+
+@dataclass
+class MapSpec:
+    group: str
+    name: str
+    data_path: str
+    wcs_path: str
+
+
+def _decode_h5_string(value) -> str:
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode()
+    if isinstance(value, np.ndarray) and value.dtype.kind in ("S", "O"):
+        item = value[()]
+        if isinstance(item, (bytes, bytearray)):
+            return item.decode()
+        return str(item)
+    return str(value)
+
+
+def _safe_header_from_string(text: str) -> fits.Header:
+    header = fits.Header()
+    for raw in text.splitlines():
+        if not raw:
+            continue
+        key = raw[:8].strip()
+        if not key or key in ("END", "CONTINUE"):
+            continue
+        line = raw
+        if len(line) < 80:
+            line = line.ljust(80)
+        if len(line) > 80:
+            line = line[:80]
+        try:
+            card = fits.Card.fromstring(line)
+        except Exception:
+            continue
+        header.append(card, end=True)
+    return header
+
+
+def _collect_maps(h5f: h5py.File) -> list[MapSpec]:
+    specs: list[MapSpec] = []
+
+    base_header_path = None
+    if "base" in h5f:
+        if "index" in h5f["base"]:
+            base_header_path = "base/index"
+        elif "index_header" in h5f["base"]:
+            base_header_path = "base/index_header"
+        elif "wcs_header" in h5f["base"]:
+            base_header_path = "base/wcs_header"
+
+    if base_header_path is not None:
+        for key in ("bx", "by", "bz", "ic", "chromo_mask"):
+            if key in h5f["base"]:
+                specs.append(
+                    MapSpec(
+                        group="base",
+                        name=key,
+                        data_path=f"base/{key}",
+                        wcs_path=base_header_path,
+                    )
+                )
+
+    if "refmaps" in h5f:
+        for name in sorted(h5f["refmaps"].keys()):
+            group = h5f["refmaps"][name]
+            if "data" in group and "wcs_header" in group:
+                specs.append(
+                    MapSpec(
+                        group="refmaps",
+                        name=name,
+                        data_path=f"refmaps/{name}/data",
+                        wcs_path=f"refmaps/{name}/wcs_header",
+                    )
+                )
+
+    return specs
+
+
+class RefmapViewer(QtWidgets.QMainWindow):
+    def __init__(self, h5_path: Path, start: Optional[str] = None):
+        super().__init__()
+        self.h5_path = h5_path
+        self.setWindowTitle(f"gxrefmap-view: {h5_path.name}")
+        self._data_min = None
+        self._data_max = None
+        self._suppress_slider = False
+
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout()
+        central.setLayout(layout)
+        self.setCentralWidget(central)
+
+        self.selector = QtWidgets.QComboBox()
+        layout.addWidget(self.selector)
+
+        controls = QtWidgets.QHBoxLayout()
+        self.vmin_label = QtWidgets.QLabel("Vmin:")
+        self.vmin_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.vmin_slider.setMinimum(0)
+        self.vmin_slider.setMaximum(1000)
+        self.vmin_value = QtWidgets.QLabel("")
+        self.vmax_label = QtWidgets.QLabel("Vmax:")
+        self.vmax_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.vmax_slider.setMinimum(0)
+        self.vmax_slider.setMaximum(1000)
+        self.vmax_value = QtWidgets.QLabel("")
+        self.log_checkbox = QtWidgets.QCheckBox("Log scale")
+
+        controls.addWidget(self.vmin_label)
+        controls.addWidget(self.vmin_slider)
+        controls.addWidget(self.vmin_value)
+        controls.addWidget(self.vmax_label)
+        controls.addWidget(self.vmax_slider)
+        controls.addWidget(self.vmax_value)
+        controls.addWidget(self.log_checkbox)
+        layout.addLayout(controls)
+
+        self.figure = Figure(figsize=(7, 6))
+        self.canvas = FigureCanvas(self.figure)
+        self.toolbar = NavigationToolbar(self.canvas, self)
+        layout.addWidget(self.toolbar)
+        layout.addWidget(self.canvas)
+
+        with h5py.File(self.h5_path, "r") as h5f:
+            self.map_specs = _collect_maps(h5f)
+
+        for spec in self.map_specs:
+            label = f"{spec.group}/{spec.name}"
+            self.selector.addItem(label)
+
+        self.selector.currentIndexChanged.connect(self._update_plot)
+        self.vmin_slider.valueChanged.connect(self._update_plot)
+        self.vmax_slider.valueChanged.connect(self._update_plot)
+        self.log_checkbox.stateChanged.connect(self._update_plot)
+
+        if start:
+            for idx, spec in enumerate(self.map_specs):
+                if spec.name == start or f"{spec.group}/{spec.name}" == start:
+                    self.selector.setCurrentIndex(idx)
+                    break
+
+        self._update_plot()
+
+    def _update_plot(self) -> None:
+        idx = self.selector.currentIndex()
+        if idx < 0 or idx >= len(self.map_specs):
+            return
+        spec = self.map_specs[idx]
+
+        try:
+            with h5py.File(self.h5_path, "r") as h5f:
+                data = h5f[spec.data_path][()]
+                wcs_header = _decode_h5_string(h5f[spec.wcs_path][()])
+        except Exception as exc:
+            self.statusBar().showMessage(f"Failed to read {spec.group}/{spec.name}: {exc}")
+            return
+
+        header = _safe_header_from_string(wcs_header)
+        self.figure.clear()
+        cmap = None
+        norm = None
+        if spec.name == "chromo_mask":
+            cmap = colors.ListedColormap([
+                "#000000", "#1f77b4", "#ff7f0e", "#2ca02c",
+                "#d62728", "#9467bd", "#8c564b", "#e377c2",
+                "#7f7f7f", "#bcbd22"
+            ])
+            norm = colors.BoundaryNorm(np.arange(0.5, 10.5, 1), cmap.N)
+        elif spec.name == "Vert_current":
+            vmax = np.nanmax(np.abs(data)) if np.isfinite(data).any() else 1.0
+            norm = colors.TwoSlopeNorm(vmin=-vmax, vcenter=0.0, vmax=vmax)
+            cmap = "seismic"
+
+        data_min = float(np.nanmin(data))
+        data_max = float(np.nanmax(data))
+        if self._data_min != data_min or self._data_max != data_max:
+            self._data_min = data_min
+            self._data_max = data_max
+            self._suppress_slider = True
+            self.vmin_slider.setValue(0)
+            self.vmax_slider.setValue(1000)
+            self._suppress_slider = False
+
+        if not self._suppress_slider:
+            smin = self.vmin_slider.value()
+            smax = self.vmax_slider.value()
+            if smin > smax:
+                self._suppress_slider = True
+                if self.sender() is self.vmin_slider:
+                    smin = smax
+                    self.vmin_slider.setValue(smin)
+                else:
+                    smax = smin
+                    self.vmax_slider.setValue(smax)
+                self._suppress_slider = False
+            vmin = self._data_min + (self._data_max - self._data_min) * (smin / 1000.0)
+            vmax = self._data_min + (self._data_max - self._data_min) * (smax / 1000.0)
+            self.vmin_value.setText(f"{vmin:.3g}")
+            self.vmax_value.setText(f"{vmax:.3g}")
+        else:
+            vmin = self._data_min
+            vmax = self._data_max
+
+        log_ok = vmin > 0 and vmax > 0
+        if spec.name in ("chromo_mask", "bx", "by", "bz", "Vert_current"):
+            log_ok = False
+        self.log_checkbox.setEnabled(log_ok)
+        if not log_ok:
+            self.log_checkbox.setChecked(False)
+
+        if spec.name not in ("chromo_mask",):
+            if self.log_checkbox.isChecked() and vmin > 0:
+                norm = colors.LogNorm(vmin=vmin, vmax=vmax)
+            else:
+                if vmin < 0 < vmax:
+                    norm = colors.TwoSlopeNorm(vmin=vmin, vcenter=0.0, vmax=vmax)
+                else:
+                    norm = colors.Normalize(vmin=vmin, vmax=vmax)
+
+        im = None
+        used_sunpy = False
+        try:
+            smap = sunpy.map.Map(data, header)
+            ax = self.figure.add_subplot(111, projection=smap)
+            im = smap.plot(axes=ax, cmap=cmap, norm=norm)
+            used_sunpy = True
+        except Exception:
+            try:
+                from astropy.wcs import WCS
+                wcs = WCS(header)
+                ax = self.figure.add_subplot(111, projection=wcs)
+                im = ax.imshow(data, origin="lower", cmap=cmap, norm=norm)
+            except Exception:
+                ax = self.figure.add_subplot(111)
+                im = ax.imshow(data, origin="lower", cmap=cmap, norm=norm)
+
+        if not used_sunpy:
+            ax.set_xlabel("X [arcsec]")
+            ax.set_ylabel("Y [arcsec]")
+        ax.set_title(f"{spec.group}/{spec.name} (min={self._data_min:.3g}, max={self._data_max:.3g})")
+        if im is not None:
+            try:
+                self.figure.colorbar(im, ax=ax, orientation="vertical", shrink=0.85, pad=0.02)
+            except Exception:
+                pass
+        self.canvas.draw()
+
+
+@app.command()
+def main(
+    ctx: typer.Context,
+    h5_path: Optional[Path] = typer.Argument(None, exists=True, file_okay=True, dir_okay=False, readable=True),
+    h5: Optional[Path] = typer.Option(
+        None,
+        "--h5",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Path to the model HDF5 file.",
+    ),
+    start: Optional[str] = typer.Option(None, "--start", help="Initial map name to display."),
+    list_only: bool = typer.Option(False, "--list", help="List available maps and exit."),
+) -> None:
+    if h5_path is None and h5 is None:
+        print(ctx.get_help())
+        raise typer.Exit(code=0)
+    if h5_path is None:
+        h5_path = h5
+
+    with h5py.File(h5_path, "r") as h5f:
+        specs = _collect_maps(h5f)
+    if list_only:
+        for spec in specs:
+            print(f"{spec.group}/{spec.name}")
+        raise typer.Exit(code=0)
+
+    app_qt = QtWidgets.QApplication.instance()
+    if app_qt is None:
+        app_qt = QtWidgets.QApplication([])
+
+    viewer = RefmapViewer(h5_path, start=start)
+    viewer.resize(900, 700)
+    viewer.show()
+    app_qt.exec_()
+
+
+if __name__ == "__main__":
+    app()

--- a/pyampp/gxbox/gxrefmap_view.py
+++ b/pyampp/gxbox/gxrefmap_view.py
@@ -264,6 +264,7 @@ class RefmapViewer(QtWidgets.QMainWindow):
             try:
                 self.figure.colorbar(im, ax=ax, orientation="vertical", shrink=0.85, pad=0.02)
             except Exception:
+                # Colorbar rendering is cosmetic; ignore any errors to avoid breaking the viewer.
                 # Colorbar rendering is cosmetic; keep viewer usable if it fails.
                 pass
         self.canvas.draw()

--- a/pyampp/gxbox/gxrefmap_view.py
+++ b/pyampp/gxbox/gxrefmap_view.py
@@ -13,7 +13,6 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
 from matplotlib import colors
-import astropy.units as u
 import sunpy.map
 
 app = typer.Typer(help="View refmaps and base maps stored in a model HDF5 file.")
@@ -265,6 +264,7 @@ class RefmapViewer(QtWidgets.QMainWindow):
             try:
                 self.figure.colorbar(im, ax=ax, orientation="vertical", shrink=0.85, pad=0.02)
             except Exception:
+                # Colorbar rendering is cosmetic; keep viewer usable if it fails.
                 pass
         self.canvas.draw()
 

--- a/pyampp/gxbox/magfield_viewer.py
+++ b/pyampp/gxbox/magfield_viewer.py
@@ -1120,12 +1120,10 @@ class MagFieldViewer(BackgroundPlotter):
         else:
             if slice_z==0:
                 slice_z = 1.0e-6
-            use_scalar_arg = True
             if use_interp:
                 new_slice = self.grid.slice(normal='z', origin=(self.grid.origin[0], self.grid.origin[1], slice_z))
                 pref = 'point'
                 scalar_name = scalar
-                use_scalar_arg = True
                 scalars = scalar_name
             else:
                 spacing_z = self.grid_spacing[2]
@@ -1156,7 +1154,6 @@ class MagFieldViewer(BackgroundPlotter):
                     new_slice = self.grid.slice(normal='z', origin=(self.grid.origin[0], self.grid.origin[1], slice_z))
                     pref = 'point'
                     scalar_name = scalar
-                    use_scalar_arg = True
                     scalars = scalar_name
                     if self.bottom_slice_actor is None:
                         self.bottom_slice_actor = self.add_mesh(new_slice, scalars=scalars, clim=(vmin, vmax), show_edges=False,
@@ -1177,7 +1174,6 @@ class MagFieldViewer(BackgroundPlotter):
                         new_slice = self.grid.slice(normal='z', origin=(self.grid.origin[0], self.grid.origin[1], slice_z))
                         pref = 'point'
                         scalar_name = scalar
-                        use_scalar_arg = True
                         scalars = scalar_name
                         if self.bottom_slice_actor is None:
                             self.bottom_slice_actor = self.add_mesh(new_slice, scalars=scalars, clim=(vmin, vmax), show_edges=False,
@@ -1200,7 +1196,6 @@ class MagFieldViewer(BackgroundPlotter):
                 new_slice.cell_data[scalar_name] = flat_slice
                 new_slice.set_active_scalars(scalar_name, preference='cell')
                 pref = 'cell'
-                use_scalar_arg = True
                 scalars = scalar_name
             if self.bottom_slice_actor is None:
                 self.bottom_slice_actor = self.add_mesh(new_slice, scalars=scalars, clim=(vmin, vmax), show_edges=False,

--- a/pyampp/gxbox/magfield_viewer.py
+++ b/pyampp/gxbox/magfield_viewer.py
@@ -1,5 +1,5 @@
 from PyQt5.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QHBoxLayout, QWidget, QComboBox, QLabel, \
-    QPushButton, QSlider, QLineEdit, QCheckBox, QMessageBox, QMenu, QHeaderView, QFileDialog, QAction, QToolButton, \
+    QPushButton, QDoubleSpinBox, QLineEdit, QCheckBox, QMessageBox, QMenu, QHeaderView, QFileDialog, QAction, QToolButton, \
     QToolBar
 from PyQt5.QtCore import Qt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
@@ -72,6 +72,7 @@ class MagFieldViewer(BackgroundPlotter):
         self.streamlines = None
         self.sphere_visible = True
         self.plane_visible = True
+        self.use_interp = True
         self.scalar = 'bz'
         self.previous_params = {}
         self.previous_valid_values = {}
@@ -85,11 +86,20 @@ class MagFieldViewer(BackgroundPlotter):
         self.slice_z_input = None
         self.vmin_input = None
         self.vmax_input = None
+        self.slice_z_min = 0.0
+        self.slice_z_max = 0.0
+        self.scalar_min = 0.0
+        self.scalar_max = 0.0
         self.update_button = None
         self.send_button = None
         self.parallel_proj_button = None
         self.timestr = time.to_datetime().strftime("_%Y%m%dT%H%M%S") if time is not None else ''
-        self.b3dtype = b3dtype
+        if b3dtype in ("pot", "nlfff"):
+            self.b3dtype = "corona"
+            self.corona_type = b3dtype
+        else:
+            self.b3dtype = b3dtype
+            self.corona_type = None
         # self.sphere_checkbox = None
         self.grid_x = self.box.grid_coords['x'].value
         self.grid_y = self.box.grid_coords['y'].value
@@ -434,11 +444,15 @@ class MagFieldViewer(BackgroundPlotter):
 
         slice_z_label = QLabel("Z [Mm]:")
         slice_z_label.setToolTip(f"Enter the Z coordinate for the slice in the range of 0 to {self.grid_zmax:.2f} Mm.")
-        self.slice_z_input = QLineEdit(
-            f"{0:.2f}")
-        self.slice_z_input.returnPressed.connect(lambda: self._on_slice_z_input_returnPressed(self.slice_z_input))
+        self.slice_z_input = QDoubleSpinBox()
+        self.slice_z_input.setDecimals(2)
+        self.slice_z_input.setRange(0, self.grid_zmax)
+        self.slice_z_input.setSingleStep(max(self.grid_zmax / 200, 0.1))
+        self.slice_z_input.setAccelerated(True)
+        self.slice_z_input.setValue(0.0)
+        self.slice_z_input.valueChanged.connect(lambda: self._on_slice_z_input_returnPressed(self.slice_z_input))
         self.slice_z_input.setToolTip(
-            f"Enter the Z coordinate for the slice in the range of 0 to {self.grid_zmax:.2f} Mm.")
+            f"Use arrows or mouse wheel. Range: 0 to {self.grid_zmax:.2f} Mm.")
         slice_control_layout.addWidget(slice_z_label)
         slice_control_layout.addWidget(self.slice_z_input)
 
@@ -453,21 +467,37 @@ class MagFieldViewer(BackgroundPlotter):
 
         vmin_vmax_label = QLabel("Vmin/Vmax [G]:")
         vmin_vmax_label.setToolTip("Enter the minimum and maximum values for the color scale.")
-        self.vmin_input = QLineEdit("-1000")
-        self.vmin_input.setToolTip("Enter the minimum value for the color scale.")
-        self.vmin_input.returnPressed.connect(lambda: self._on_vmin_input_returnPressed(self.vmin_input))
+        self.vmin_input = QDoubleSpinBox()
+        self.vmin_input.setDecimals(2)
+        self.vmin_input.setRange(-5e4, 5e4)
+        self.vmin_input.setSingleStep(10.0)
+        self.vmin_input.setAccelerated(True)
+        self.vmin_input.setValue(-1000.0)
+        self.vmin_input.valueChanged.connect(lambda: self._on_vmin_input_returnPressed(self.vmin_input))
+        self.vmin_input.setToolTip("Use arrows or mouse wheel to change Vmin.")
         slice_control_layout.addWidget(vmin_vmax_label)
         slice_control_layout.addWidget(self.vmin_input)
 
-        self.vmax_input = QLineEdit("1000")
-        self.vmax_input.setToolTip("Enter the maximum value for the color scale.")
-        self.vmax_input.returnPressed.connect(lambda: self._on_vmax_input_returnPressed(self.vmax_input))
+        self.vmax_input = QDoubleSpinBox()
+        self.vmax_input.setDecimals(2)
+        self.vmax_input.setRange(-5e4, 5e4)
+        self.vmax_input.setSingleStep(10.0)
+        self.vmax_input.setAccelerated(True)
+        self.vmax_input.setValue(1000.0)
+        self.vmax_input.valueChanged.connect(lambda: self._on_vmax_input_returnPressed(self.vmax_input))
+        self.vmax_input.setToolTip("Use arrows or mouse wheel to change Vmax.")
         slice_control_layout.addWidget(self.vmax_input)
 
         self.plane_checkbox = QCheckBox("Show Plane")
         self.plane_checkbox.setChecked(True)
         self.plane_checkbox.stateChanged.connect(self.toggle_plane_visibility)
         slice_control_layout.addWidget(self.plane_checkbox)
+
+        self.interp_checkbox = QCheckBox("Interpolate")
+        self.interp_checkbox.setChecked(True)
+        self.interp_checkbox.setToolTip("Toggle interpolation for slice display.")
+        self.interp_checkbox.stateChanged.connect(self.update_plot)
+        slice_control_layout.addWidget(self.interp_checkbox)
         slice_control_layout.addStretch()
 
         slice_control_group.setLayout(slice_control_layout)
@@ -832,13 +862,19 @@ class MagFieldViewer(BackgroundPlotter):
             The valid value.
         '''
         try:
-            value = float(widget.text())
+            if isinstance(widget, QDoubleSpinBox):
+                value = float(widget.value())
+            else:
+                value = float(widget.text())
             if not min_val <= value <= max_val:
                 original_value = min_val if value < min_val else max_val
                 raise ValueError
 
             if paired_widget:
-                paired_value = float(paired_widget.text())
+                if isinstance(paired_widget, QDoubleSpinBox):
+                    paired_value = float(paired_widget.value())
+                else:
+                    paired_value = float(paired_widget.text())
                 if paired_type == 'vmin' and value >= paired_value:
                     raise ValueError
                 if paired_type == 'vmax' and value <= paired_value:
@@ -860,13 +896,54 @@ class MagFieldViewer(BackgroundPlotter):
             #     QMessageBox.warning(self, "Invalid Input",
             #                         f"Please enter a number between {min_val:.3f} and {max_val:.3f}. Revert to the original value.")
 
-            widget.setText(str(original_value))
+            if isinstance(widget, QDoubleSpinBox):
+                widget.setValue(float(original_value))
+            else:
+                widget.setText(str(original_value))
             return original_value
+
+    def _set_slice_slider_range(self):
+        self.slice_z_min = float(self.grid_zmin)
+        self.slice_z_max = float(self.grid_zmax)
+        if self.slice_z_input is None:
+            return
+        self.slice_z_input.blockSignals(True)
+        self.slice_z_input.setRange(self.slice_z_min, self.slice_z_max)
+        step = max((self.slice_z_max - self.slice_z_min) / 200.0, 0.1)
+        self.slice_z_input.setSingleStep(step)
+        self.slice_z_input.blockSignals(False)
+
+    def _set_scalar_range(self, scalar_name):
+        data = None
+        if scalar_name in self.grid.array_names:
+            data = self.grid[scalar_name]
+        elif self.bottom_name is not None and scalar_name == self.bottom_name:
+            data = self.grid_bottom[scalar_name]
+        if data is None:
+            return
+        self.scalar_min = float(np.nanmin(data))
+        self.scalar_max = float(np.nanmax(data))
+        if self.scalar_min == self.scalar_max:
+            self.scalar_min -= 1.0
+            self.scalar_max += 1.0
+
+        if self.vmin_input is not None and self.vmax_input is not None:
+            self.vmin_input.blockSignals(True)
+            self.vmax_input.blockSignals(True)
+            self.vmin_input.setRange(self.scalar_min, self.scalar_max)
+            self.vmax_input.setRange(self.scalar_min, self.scalar_max)
+            step = max((self.scalar_max - self.scalar_min) / 200.0, 1.0)
+            self.vmin_input.setSingleStep(step)
+            self.vmax_input.setSingleStep(step)
+            self.vmin_input.blockSignals(False)
+            self.vmax_input.blockSignals(False)
 
     def init_grid(self):
         x = self.grid_x
         y = self.grid_y
         z = self.grid_z
+
+        self.bottom_name = None
 
         bx = self.box.b3d[self.b3dtype]['bx']
         by = self.box.b3d[self.b3dtype]['by']
@@ -877,6 +954,8 @@ class MagFieldViewer(BackgroundPlotter):
         self.grid.dimensions = (len(x), len(y), len(z))
         self.grid.spacing = (x[1] - x[0], y[1] - y[0], z[1] - z[0])
         self.grid.origin = (x.min(), y.min(), z.min())
+        self.grid_dims = (len(x), len(y), len(z))
+        self.grid_spacing = self.grid.spacing
 
         self.grid['bx'] = bx.ravel(order='F')
         self.grid['by'] = by.ravel(order='F')
@@ -888,25 +967,36 @@ class MagFieldViewer(BackgroundPlotter):
         self.grid_bottom.dimensions = (len(x), len(y), 1)
         self.grid_bottom.spacing = (x[1] - x[0], y[1] - y[0], 0)
         self.grid_bottom.origin = (x.min(), y.min(), z.min())
-        self.bottom_name = self.parent.mapBottomSelector.currentText()
-        self.grid_bottom[self.bottom_name] = self.parent.map_bottom.data.T.ravel(order='F')
-        self.scalar_selector_items.append(self.bottom_name)
+        if self.parent is not None and hasattr(self.parent, "mapBottomSelector") and hasattr(self.parent, "map_bottom"):
+            self.bottom_name = self.parent.mapBottomSelector.currentText()
+            self.grid_bottom[self.bottom_name] = self.parent.map_bottom.data.T.ravel(order='F')
+            self.scalar_selector_items.append(self.bottom_name)
+
+        self._set_slice_slider_range()
+        self._set_scalar_range(self.scalar)
 
 
     def init_plot(self):
         """
         Initializes and displays the plot with the magnetic field data.
         """
+        self._set_slice_slider_range()
+        self._set_scalar_range(self.scalar)
+
+        def _val(widget):
+            if isinstance(widget, QDoubleSpinBox):
+                return float(widget.value())
+            return float(widget.text())
 
         self.previous_valid_values = {
-            self.center_x_input: float(self.center_x_input.text()),
-            self.center_y_input: float(self.center_y_input.text()),
-            self.center_z_input: float(self.center_z_input.text()),
-            self.radius_input: float(self.radius_input.text()),
-            self.slice_z_input: float(self.slice_z_input.text()),
+            self.center_x_input: _val(self.center_x_input),
+            self.center_y_input: _val(self.center_y_input),
+            self.center_z_input: _val(self.center_z_input),
+            self.radius_input: _val(self.radius_input),
+            self.slice_z_input: _val(self.slice_z_input),
             self.n_points_input: int(self.n_points_input.text()),
-            self.vmin_input: float(self.vmin_input.text()),
-            self.vmax_input: float(self.vmax_input.text())
+            self.vmin_input: _val(self.vmin_input),
+            self.vmax_input: _val(self.vmax_input)
         }
 
         self.update_plot(init=True)
@@ -937,16 +1027,17 @@ class MagFieldViewer(BackgroundPlotter):
             self.update_sphere()
 
         self.update_plane()
+        scalar = self.scalar_selector.currentText()
+        self._set_scalar_range(scalar)
         slice_z = self.validate_input(self.slice_z_input, 0, self.grid_zmax,
                                       self.previous_valid_values[self.slice_z_input])
         vmin = self.validate_input(self.vmin_input, -5e4, 5e4, self.previous_valid_values[self.vmin_input],
                                    paired_widget=self.vmax_input, paired_type='vmin')
         vmax = self.validate_input(self.vmax_input, -5e4, 5e4, self.previous_valid_values[self.vmax_input],
                                    paired_widget=self.vmin_input, paired_type='vmax')
-
-        scalar = self.scalar_selector.currentText()
         sphere_visible = self.viz_sphere_button.isChecked()
         plane_visible = self.plane_visible
+        use_interp = self.interp_checkbox.isChecked() if self.interp_checkbox is not None else True
 
         # Create a dictionary of current parameters
         current_params = {
@@ -959,6 +1050,7 @@ class MagFieldViewer(BackgroundPlotter):
             "vmin": vmin,
             "vmax": vmax,
             "scalar": scalar,
+            "use_interp": use_interp,
             "sphere_visible": sphere_visible,
             "plane_visible": plane_visible
         }
@@ -972,9 +1064,10 @@ class MagFieldViewer(BackgroundPlotter):
         if current_params['slice_z'] != self.previous_params.get('slice_z') or \
                 current_params['scalar'] != self.previous_params.get('scalar') or \
                 current_params['vmin'] != self.previous_params.get('vmin') or \
-                current_params['vmax'] != self.previous_params.get('vmax'):
+                current_params['vmax'] != self.previous_params.get('vmax') or \
+                current_params['use_interp'] != self.previous_params.get('use_interp'):
             self.update_slice(current_params['slice_z'], current_params['scalar'], current_params['vmin'],
-                              current_params['vmax'])
+                              current_params['vmax'], current_params['use_interp'])
 
         if current_params['plane_visible'] != self.previous_params.get('plane_visible'):
             self.update_plane_visibility(current_params['plane_visible'])
@@ -999,7 +1092,7 @@ class MagFieldViewer(BackgroundPlotter):
         self.updating_flag = False  # Reset the flag
         self.reset_camera_clipping_range()
 
-    def update_slice(self, slice_z, scalar, vmin, vmax):
+    def update_slice(self, slice_z, scalar, vmin, vmax, use_interp=True):
         """
         Updates the slice plot based on the given parameters.
 
@@ -1012,7 +1105,7 @@ class MagFieldViewer(BackgroundPlotter):
         :param vmax: float
             The maximum value for the color scale.
         """
-        if scalar == self.bottom_name:
+        if self.bottom_name is not None and scalar == self.bottom_name:
             # Display the new scalar data as a 2D plane
             if self.bottom_slice_actor is None:
                 self.bottom_slice_actor = self.add_mesh(self.grid_bottom, scalars=scalar, clim=(vmin, vmax),
@@ -1027,15 +1120,97 @@ class MagFieldViewer(BackgroundPlotter):
         else:
             if slice_z==0:
                 slice_z = 1.0e-6
-            new_slice = self.grid.slice(normal='z', origin=(self.grid.origin[0], self.grid.origin[1], slice_z))
+            use_scalar_arg = True
+            if use_interp:
+                new_slice = self.grid.slice(normal='z', origin=(self.grid.origin[0], self.grid.origin[1], slice_z))
+                pref = 'point'
+                scalar_name = scalar
+                use_scalar_arg = True
+                scalars = scalar_name
+            else:
+                spacing_z = self.grid_spacing[2]
+                idx = int(round((slice_z - self.grid.origin[2]) / spacing_z))
+                idx = max(0, min(idx, self.grid_dims[2] - 1))
+                z_pos = slice_z
+
+                nx, ny, nz = self.grid_dims
+                if scalar in ('bx', 'by', 'bz'):
+                    cube = self.box.b3d[self.b3dtype][scalar]
+                else:
+                    cube = self.box.b3d[self.b3dtype]['bz']
+
+                cube = np.asarray(cube)
+                if cube.ndim == 4 and cube.shape[-1] == 3 and scalar in ('bx', 'by', 'bz'):
+                    comp_idx = {'bx': 0, 'by': 1, 'bz': 2}[scalar]
+                    cube = cube[..., comp_idx]
+
+                if cube.ndim != 3 and cube.size == nx * ny * nz:
+                    cube = cube.reshape((nx, ny, nz), order='F')
+
+                if cube.ndim == 3:
+                    slice_data = cube[:, :, idx]
+                elif cube.ndim == 2 and cube.size == nx * ny:
+                    slice_data = cube
+                else:
+                    # Fallback to interpolated slice if cube shape is unexpected
+                    new_slice = self.grid.slice(normal='z', origin=(self.grid.origin[0], self.grid.origin[1], slice_z))
+                    pref = 'point'
+                    scalar_name = scalar
+                    use_scalar_arg = True
+                    scalars = scalar_name
+                    if self.bottom_slice_actor is None:
+                        self.bottom_slice_actor = self.add_mesh(new_slice, scalars=scalars, clim=(vmin, vmax), show_edges=False,
+                                                                cmap='gray', pickable=False, show_scalar_bar=False,
+                                                                preference=pref)
+                    else:
+                        self.remove_actor(self.bottom_slice_actor)
+                        self.bottom_slice_actor = self.add_mesh(new_slice, scalars=scalars, clim=(vmin, vmax), show_edges=False,
+                                                                cmap='gray', pickable=False, reset_camera=False,
+                                                                show_scalar_bar=False, preference=pref)
+                    return
+
+                if slice_data.size != nx * ny:
+                    if slice_data.size == nx * ny:
+                        slice_data = slice_data.reshape((nx, ny), order='F')
+                    else:
+                        # Fallback to interpolated slice if reshaping is impossible
+                        new_slice = self.grid.slice(normal='z', origin=(self.grid.origin[0], self.grid.origin[1], slice_z))
+                        pref = 'point'
+                        scalar_name = scalar
+                        use_scalar_arg = True
+                        scalars = scalar_name
+                        if self.bottom_slice_actor is None:
+                            self.bottom_slice_actor = self.add_mesh(new_slice, scalars=scalars, clim=(vmin, vmax), show_edges=False,
+                                                                    cmap='gray', pickable=False, show_scalar_bar=False,
+                                                                    preference=pref)
+                        else:
+                            self.remove_actor(self.bottom_slice_actor)
+                            self.bottom_slice_actor = self.add_mesh(new_slice, scalars=scalars, clim=(vmin, vmax), show_edges=False,
+                                                                    cmap='gray', pickable=False, reset_camera=False,
+                                                                    show_scalar_bar=False, preference=pref)
+                        return
+
+                flat_slice = slice_data.ravel(order='F')
+                spacing_x = (self.grid_xmax - self.grid_xmin) / float(nx)
+                spacing_y = (self.grid_ymax - self.grid_ymin) / float(ny)
+                scalar_name = "slice_scalar"
+                new_slice = pv.ImageData(dimensions=(nx + 1, ny + 1, 1),
+                                         spacing=(spacing_x, spacing_y, 1),
+                                         origin=(self.grid_xmin, self.grid_ymin, z_pos))
+                new_slice.cell_data[scalar_name] = flat_slice
+                new_slice.set_active_scalars(scalar_name, preference='cell')
+                pref = 'cell'
+                use_scalar_arg = True
+                scalars = scalar_name
             if self.bottom_slice_actor is None:
-                self.bottom_slice_actor = self.add_mesh(new_slice, scalars=scalar, clim=(vmin, vmax), show_edges=False,
-                                                        cmap='gray', pickable=False, show_scalar_bar=False)
+                self.bottom_slice_actor = self.add_mesh(new_slice, scalars=scalars, clim=(vmin, vmax), show_edges=False,
+                                                        cmap='gray', pickable=False, show_scalar_bar=False,
+                                                        preference=pref)
             else:
                 self.remove_actor(self.bottom_slice_actor)
-                self.bottom_slice_actor = self.add_mesh(new_slice, scalars=scalar, clim=(vmin, vmax), show_edges=False,
+                self.bottom_slice_actor = self.add_mesh(new_slice, scalars=scalars, clim=(vmin, vmax), show_edges=False,
                                                         cmap='gray', pickable=False, reset_camera=False,
-                                                        show_scalar_bar=False)
+                                                        show_scalar_bar=False, preference=pref)
 
     def create_streamlines(self, center_x, center_y, center_z, radius, n_points):
         self.streamlines = self.grid.streamlines(vectors='vectors', source_center=(center_x, center_y, center_z),
@@ -1191,7 +1366,6 @@ class MagFieldViewer(BackgroundPlotter):
         :param center: list of float
             The new center coordinates of the sphere.
         """
-        print('calling _on_sphere_moved')
         self.center_x_input.setText(f"{center[0]:.2f}")
         self.center_y_input.setText(f"{center[1]:.2f}")
         self.center_z_input.setText(f"{center[2]:.2f}")
@@ -1241,7 +1415,7 @@ class MagFieldViewer(BackgroundPlotter):
         """
         if self.plane_actor is not None:
             origin = np.ptp(self.grid_x) / 2, np.ptp(self.grid_y) / 2
-            slice_z = float(self.slice_z_input.text())
+            slice_z = float(self.slice_z_input.value()) if isinstance(self.slice_z_input, QDoubleSpinBox) else float(self.slice_z_input.text())
             self.plane_actor.SetOrigin([origin[0], origin[1], slice_z])
             self.update_plot()
 
@@ -1255,7 +1429,7 @@ class MagFieldViewer(BackgroundPlotter):
         if plane_visible:
             if self.plane_actor is None:
                 origin = np.ptp(self.grid_x) / 2, np.ptp(self.grid_y) / 2
-                slice_z = float(self.slice_z_input.text())
+                slice_z = float(self.slice_z_input.value()) if isinstance(self.slice_z_input, QDoubleSpinBox) else float(self.slice_z_input.text())
                 self.plane_actor = self.add_plane_widget(self._on_plane_moved, normal='z',
                                                          origin=(origin[0], origin[1], slice_z), bounds=(
                         self.grid_xmin, self.grid_xmax, self.grid_ymin, self.grid_ymax, self.grid_zmin, self.grid_zmax),
@@ -1275,7 +1449,10 @@ class MagFieldViewer(BackgroundPlotter):
         :param origin: list of float
             The new origin coordinates of the plane.
         """
-        self.slice_z_input.setText(f"{origin[2]:.2f}")
+        if isinstance(self.slice_z_input, QDoubleSpinBox):
+            self.slice_z_input.setValue(float(origin[2]))
+        else:
+            self.slice_z_input.setText(f"{origin[2]:.2f}")
         self.update_plane()
 
     def toggle_plane_visibility(self, state):
@@ -1312,6 +1489,27 @@ class MagFieldViewer(BackgroundPlotter):
     def load_box(self):
         default_filename = "b3d_data.h5"
         filename = QFileDialog.getOpenFileName(self, "Load Box", default_filename, "HDF5 Files (*.h5)")[0]
+        if not filename:
+            return
         self.box.b3d = read_b3d_h5(filename)
+
+        if "corona" in self.box.b3d:
+            self.b3dtype = "corona"
+        elif "nlfff" in self.box.b3d:
+            self.b3dtype = "corona"
+            self.box.b3d["corona"] = self.box.b3d.pop("nlfff")
+        elif "pot" in self.box.b3d:
+            self.b3dtype = "corona"
+            self.box.b3d["corona"] = self.box.b3d.pop("pot")
+        elif "chromo" in self.box.b3d:
+            self.b3dtype = "chromo"
+            chromo = self.box.b3d.get("chromo", {})
+            if "bx" not in chromo and "bcube" in chromo:
+                bcube = chromo["bcube"]
+                if bcube.ndim == 4 and bcube.shape[-1] == 3:
+                    chromo["bx"] = bcube[:, :, :, 0]
+                    chromo["by"] = bcube[:, :, :, 1]
+                    chromo["bz"] = bcube[:, :, :, 2]
+                    self.box.b3d["chromo"] = chromo
         self.init_grid()
         self.update_plot()

--- a/pyampp/gxbox/view_h5.py
+++ b/pyampp/gxbox/view_h5.py
@@ -94,11 +94,6 @@ def main() -> int:
         start_dir = Path(args.start_dir).expanduser() if args.start_dir else Path.cwd()
         if not start_dir.exists() or not start_dir.is_dir():
             start_dir = Path.cwd()
-        picker_start = str(start_dir)
-        if h5_arg:
-            candidate = Path(h5_arg).expanduser()
-            if candidate.exists():
-                picker_start = str(candidate)
         dialog = QFileDialog(None, "Open HDF5 Model")
         # Native macOS picker may ignore selectFile(); use Qt dialog for reliable preselection.
         dialog.setOption(QFileDialog.DontUseNativeDialog, True)

--- a/pyampp/gxbox/view_h5.py
+++ b/pyampp/gxbox/view_h5.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import warnings
+try:
+    from pyvista import PyVistaDeprecationWarning
+except Exception:
+    PyVistaDeprecationWarning = DeprecationWarning
+from pathlib import Path
+
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from astropy.time import Time
+from sunpy.coordinates import Heliocentric, get_earth
+from sunpy.sun import constants as sun_consts
+
+from pyampp.gxbox.boxutils import read_b3d_h5
+from pyampp.gxbox.magfield_viewer import MagFieldViewer
+from PyQt5.QtWidgets import QApplication, QFileDialog
+
+
+@dataclass
+class SimpleBox:
+    dims_pix: np.ndarray
+    res: u.Quantity
+    b3d: dict
+    _frame_obs: object
+    _center: SkyCoord
+
+    @property
+    def grid_coords(self):
+        dims = self.dims_pix
+        dx = self.res
+        x = np.linspace(-dims[0] / 2, dims[0] / 2, dims[0]) * dx
+        y = np.linspace(-dims[1] / 2, dims[1] / 2, dims[1]) * dx
+        z = np.linspace(-dims[2] / 2, dims[2] / 2, dims[2]) * dx
+        return {"x": x, "y": y, "z": z, "frame": self._frame_obs}
+
+
+def infer_dims(b3d: dict) -> np.ndarray:
+    for key in ("corona", "nlfff", "pot"):
+        if key in b3d and "bx" in b3d[key]:
+            return np.array(b3d[key]["bx"].shape, dtype=int)
+    if "chromo" in b3d:
+        if "bcube" in b3d["chromo"]:
+            return np.array(b3d["chromo"]["bcube"].shape[:3], dtype=int)
+        if "chromo_bcube" in b3d["chromo"]:
+            return np.array(b3d["chromo"]["chromo_bcube"].shape[1:4], dtype=int)
+    raise ValueError("Unable to infer dimensions from HDF5.")
+
+
+def infer_time(b3d: dict) -> Time:
+    if "chromo" in b3d and "attrs" in b3d["chromo"]:
+        attrs = b3d["chromo"]["attrs"]
+        if "obs_time" in attrs:
+            try:
+                return Time(attrs["obs_time"])
+            except Exception:
+                pass
+    return Time.now()
+
+
+def infer_res(b3d: dict) -> u.Quantity:
+    if "corona" in b3d and "dr" in b3d["corona"]:
+        dr = b3d["corona"]["dr"]
+        if dr is not None and np.size(dr) >= 1:
+            return (dr[0] * sun_consts.radius.to(u.km).value) * u.km
+    if "chromo" in b3d and "dr" in b3d["chromo"]:
+        dr = b3d["chromo"]["dr"]
+        if dr is not None and np.size(dr) >= 1:
+            return (dr[0] * sun_consts.radius.to(u.km).value) * u.km
+    return 1.0 * u.Mm
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Open a saved HDF5 model in the 3D viewer without recomputing.")
+    parser.add_argument("h5_path", nargs="?", help="Path to the HDF5 model file (positional).")
+    parser.add_argument("--h5", dest="h5_opt", help="Path to the HDF5 model file.")
+    parser.add_argument("--dir", dest="start_dir", help="Initial directory for file picker when no model path is given.")
+    parser.add_argument("--pick", action="store_true", help="Open file picker even when model path is provided.")
+    args = parser.parse_args()
+
+    h5_arg = args.h5_opt or args.h5_path
+    app = QApplication.instance()
+    owns_app = False
+    if app is None:
+        app = QApplication([])
+        owns_app = True
+
+    if args.pick or not h5_arg:
+        start_dir = Path(args.start_dir).expanduser() if args.start_dir else Path.cwd()
+        if not start_dir.exists() or not start_dir.is_dir():
+            start_dir = Path.cwd()
+        picker_start = str(start_dir)
+        if h5_arg:
+            candidate = Path(h5_arg).expanduser()
+            if candidate.exists():
+                picker_start = str(candidate)
+        dialog = QFileDialog(None, "Open HDF5 Model")
+        # Native macOS picker may ignore selectFile(); use Qt dialog for reliable preselection.
+        dialog.setOption(QFileDialog.DontUseNativeDialog, True)
+        dialog.setFileMode(QFileDialog.ExistingFile)
+        dialog.setNameFilter("HDF5 Files (*.h5);;All Files (*)")
+        if h5_arg:
+            candidate = Path(h5_arg).expanduser()
+            dialog.setDirectory(str(candidate.parent if candidate.parent.exists() else start_dir))
+            dialog.selectFile(str(candidate.name))
+        else:
+            dialog.setDirectory(str(start_dir))
+        if not dialog.exec_():
+            return 0
+        selected = dialog.selectedFiles()
+        if not selected:
+            return 0
+        h5_arg = selected[0]
+
+    h5_path = Path(h5_arg).expanduser().resolve()
+    b3d = read_b3d_h5(str(h5_path))
+
+    dims = infer_dims(b3d)
+    obs_time = infer_time(b3d)
+    res = infer_res(b3d)
+
+    frame = Heliocentric(observer=get_earth(obs_time), obstime=obs_time)
+    center = SkyCoord(0 * u.Mm, 0 * u.Mm, 0 * u.Mm, frame=frame)
+    box = SimpleBox(dims_pix=dims, res=res.to(u.Mm), b3d=b3d, _frame_obs=frame, _center=center)
+
+    if "corona" in b3d:
+        b3dtype = "corona"
+    elif "nlfff" in b3d:
+        b3dtype = "corona"
+        b3d["corona"] = b3d.pop("nlfff")
+    elif "pot" in b3d:
+        b3dtype = "corona"
+        b3d["corona"] = b3d.pop("pot")
+    elif "chromo" in b3d:
+        b3dtype = "chromo"
+        chromo = b3d.get("chromo", {})
+        if "bx" not in chromo and "bcube" in chromo:
+            bcube = chromo["bcube"]
+            if bcube.ndim == 4 and bcube.shape[-1] == 3:
+                chromo["bx"] = bcube[:, :, :, 0]
+                chromo["by"] = bcube[:, :, :, 1]
+                chromo["bz"] = bcube[:, :, :, 2]
+                b3d["chromo"] = chromo
+    else:
+        raise ValueError("No known model types found in HDF5 (expected corona/chromo).")
+
+    warnings.filterwarnings("ignore", category=PyVistaDeprecationWarning)
+    viewer = MagFieldViewer(box, time=obs_time, b3dtype=b3dtype, parent=None)
+    if hasattr(viewer, "app_window"):
+        viewer.app_window.setWindowTitle(f"GxBox 3D viewer - {h5_path}")
+    viewer.show()
+    if owns_app:
+        app.exec_()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyampp/sfq/README.md
+++ b/pyampp/sfq/README.md
@@ -1,0 +1,16 @@
+# SFQ In pyAMPP
+
+This folder contains the Python rewrite of SFQ (Super Fast and Quality) magnetic-field disambiguation routines used by AMPP/GX workflows.
+
+## Source And Attribution
+
+The SFQ method and reference implementation come from the IDL package maintained by Sergey Anfinogentov.
+
+- Original source repository: https://github.com/Sergey-Anfinogentov
+- Authors: George Rudenko, Sergey Anfinogentov
+
+Please cite the original SFQ work and repository when using these routines in scientific outputs.
+
+## Integration Note
+
+The current implementation is incremental and parity-focused. Some low-level geometry/FFT backends are still injected as callables while their native Python implementations are finalized.

--- a/pyampp/sfq/__init__.py
+++ b/pyampp/sfq/__init__.py
@@ -1,0 +1,28 @@
+"""SFQ (Super Fast and Quality) disambiguation package for pyAMPP.
+
+Source attribution:
+- George Rudenko
+- Sergey Anfinogentov
+- Original IDL package: https://github.com/Sergey-Anfinogentov
+"""
+
+from .clean import sfq_clean
+from .frame import sfq_frame
+from .potential import get_str_mag, pex_bl, pex_bl_, pot_vmag
+from .step import sfq_step1
+from .utils import idl_where, norm_vec, u_grid, u_grid_box, u_str_add
+
+__all__ = [
+    "get_str_mag",
+    "sfq_frame",
+    "sfq_step1",
+    "sfq_clean",
+    "pot_vmag",
+    "pex_bl",
+    "pex_bl_",
+    "idl_where",
+    "u_grid",
+    "u_grid_box",
+    "u_str_add",
+    "norm_vec",
+]

--- a/pyampp/sfq/clean.py
+++ b/pyampp/sfq/clean.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import time
+import numpy as np
+from numpy.lib.stride_tricks import sliding_window_view
+
+
+def _conv1d_edge(arr: np.ndarray, kernel: np.ndarray, axis: int) -> np.ndarray:
+    if arr.ndim != 2:
+        raise ValueError("_conv1d_edge expects a 2D array.")
+    k = np.asarray(kernel, dtype=float)
+    ksize = int(k.size)
+    pad_l = ksize // 2
+    pad_r = ksize - 1 - pad_l
+    if axis == 0:
+        padded = np.pad(arr, ((pad_l, pad_r), (0, 0)), mode="edge")
+        out = np.empty_like(arr, dtype=float)
+        for j in range(arr.shape[1]):
+            out[:, j] = np.convolve(padded[:, j], k, mode="valid")
+        return out
+    if axis == 1:
+        padded = np.pad(arr, ((0, 0), (pad_l, pad_r)), mode="edge")
+        out = np.empty_like(arr, dtype=float)
+        for i in range(arr.shape[0]):
+            out[i, :] = np.convolve(padded[i, :], k, mode="valid")
+        return out
+    raise ValueError("axis must be 0 or 1.")
+
+
+def _box_smooth_edge(arr: np.ndarray, size: int) -> np.ndarray:
+    kernel = np.ones(int(size), dtype=float) / float(size)
+    return _conv1d_edge(_conv1d_edge(arr, kernel, axis=0), kernel, axis=1)
+
+
+def _gaussf(n: int, sigma: float) -> np.ndarray:
+    x = np.arange(int(n), dtype=float) - (int(n) - 1) / 2.0
+    sigma = float(sigma) if sigma > 0 else 1.0
+    ker = np.exp(-0.5 * (x / sigma) ** 2)
+    s = ker.sum()
+    return ker / s if s > 0 else ker
+
+
+def _pwf_smooth(arr: np.ndarray, sigma: float) -> np.ndarray:
+    n = int(np.ceil(float(sigma) * 3.0) * 2 + 1)
+    ker = _gaussf(n, sigma)
+    return _conv1d_edge(_conv1d_edge(arr, ker, axis=0), ker, axis=1)
+
+
+def _median_filter_edge(arr: np.ndarray, size: int) -> np.ndarray:
+    size = int(size)
+    pad = size // 2
+    padded = np.pad(arr, ((pad, pad), (pad, pad)), mode="edge")
+    win = sliding_window_view(padded, (size, size))
+    return np.median(win, axis=(-2, -1))
+
+
+def sfq_clean(
+    bx: np.ndarray,
+    by: np.ndarray,
+    s: int | float | None = None,
+    gauss: bool = False,
+    median: bool = False,
+    show: bool = False,
+    mode: int = 0,
+    silent: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    bxx = np.asarray(bx, dtype=float).copy()
+    byy = np.asarray(by, dtype=float).copy()
+    if bxx.shape != byy.shape:
+        raise ValueError("bx and by must have the same shape.")
+
+    if s is None:
+        t0 = time.time()
+        if not silent:
+            print("Sarting SFQ cleaning")
+        bxx, byy = sfq_clean(bxx, byy, 3, median=True, show=show, silent=True)
+        mode_i = 1 if mode != 0 else 0
+        if mode_i == 0:
+            if min(bxx.shape) > 150:
+                bxx, byy = sfq_clean(bxx, byy, 19, gauss=gauss, median=median, show=show, silent=True)
+            if min(bxx.shape) > 100:
+                bxx, byy = sfq_clean(bxx, byy, 9, gauss=gauss, median=median, show=show, silent=True)
+        bxx, byy = sfq_clean(bxx, byy, 5, gauss=gauss, median=median, show=show, silent=True)
+        bxx, byy = sfq_clean(bxx, byy, 3, median=True, show=show, silent=True)
+        if not silent:
+            dt = int(round(time.time() - t0))
+            print(f"SFQ cleaning complete in {dt} seconds")
+        return bxx, byy
+
+    s_val = float(s)
+    n = int(np.ceil(s_val * 3.0) * 2 + 1)
+    ker = _gaussf(n, s_val)
+    gaussk = float(ker[n // 2] ** 2)
+    threshold = max(bxx.size * 0.0001, 5.0)
+
+    for _ in range(301):
+        if gauss:
+            mbx = _pwf_smooth(bxx, s_val) - bxx * gaussk
+            mby = _pwf_smooth(byy, s_val) - byy * gaussk
+        else:
+            if not median:
+                sval_i = int(max(round(s_val), 1))
+                mbx = _box_smooth_edge(bxx, sval_i) - bxx / float(sval_i ** 2)
+                mby = _box_smooth_edge(byy, sval_i) - byy / float(sval_i ** 2)
+            else:
+                sval_i = int(max(round(s_val), 1))
+                mbx = _median_filter_edge(bxx, sval_i)
+                mby = _median_filter_edge(byy, sval_i)
+
+        flip = (mbx * bxx + byy * mby) < 0
+        if int(np.count_nonzero(flip)) < threshold:
+            break
+        bxx[flip] = -bxx[flip]
+        byy[flip] = -byy[flip]
+        if show:
+            pass
+
+    return bxx, byy

--- a/pyampp/sfq/frame.py
+++ b/pyampp/sfq/frame.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import time
+import numpy as np
+
+
+def sfq_frame(
+    s: dict,
+    solis: int | None = None,
+    hmi: bool = False,
+    silent: bool = False,
+    acute: bool = False,
+    pot_vmag_func=None,
+    sfq_step1_func=None,
+    sfq_clean_func=None,
+) -> dict:
+    if pot_vmag_func is None or sfq_step1_func is None or sfq_clean_func is None:
+        raise NotImplementedError("sfq_frame requires pot_vmag_func, sfq_step1_func, and sfq_clean_func.")
+
+    t0 = time.time()
+    if not silent:
+        print("starting precise potential field calculating")
+    pot = pot_vmag_func(s, simple=True)
+    if not silent:
+        print(f"Potential field calculation complete in {int(round(time.time() - t0))} seconds")
+
+    s = sfq_step1_func(s, pot, silent=silent, acute=acute)
+
+    by = np.asarray(s["t1"], dtype=float)
+    bz = np.asarray(s["t2"], dtype=float)
+    bo = 10
+    ny, nx = by.shape
+    by_pad = np.zeros((ny + 2 * bo, nx + 2 * bo), dtype=float)
+    bz_pad = np.zeros((ny + 2 * bo, nx + 2 * bo), dtype=float)
+    by_pad[bo:bo + ny, bo:bo + nx] = by
+    bz_pad[bo:bo + ny, bo:bo + nx] = bz
+
+    solis_flag = 0 if solis is None else int(solis)
+    if hmi:
+        solis_flag = 1
+    if solis_flag != 0:
+        solis_flag = 1
+
+    cleaned = sfq_clean_func(by_pad, bz_pad, mode=(solis_flag == 1))
+    if cleaned is not None:
+        by_pad, bz_pad = cleaned
+
+    s["t1"] = by_pad[bo:bo + ny, bo:bo + nx]
+    s["t2"] = bz_pad[bo:bo + ny, bo:bo + nx]
+    return s

--- a/pyampp/sfq/potential.py
+++ b/pyampp/sfq/potential.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import time
+import numpy as np
+
+from .utils import idl_where, norm_vec, u_grid, u_grid_box, u_str_add
+
+
+def get_str_mag(bx: np.ndarray, by: np.ndarray, bz: np.ndarray, apos: np.ndarray, rsun: float) -> dict:
+    bx = np.asarray(bx, dtype=float)
+    by = np.asarray(by, dtype=float)
+    bz = np.asarray(bz, dtype=float)
+    n = bx.shape
+    gr = u_grid(pos=np.asarray(apos, dtype=float), n=n)
+
+    alf = float(rsun) * np.pi / 180.0 / 3600.0
+    dsun = 1.0 / np.sin(alf)
+    tx = np.tan(gr["x"] * np.pi / 180.0 / 3600.0)
+    ty = np.tan(gr["y"] * np.pi / 180.0 / 3600.0)
+    txy2 = tx * tx + ty * ty
+    denom = txy2 + 1.0
+
+    a = dsun * txy2 / denom
+    b = (dsun * dsun * txy2 - 1.0) / denom
+    det = a * a - b
+
+    indin = idl_where(det >= 0.0)
+    indout = idl_where(det < 0.0)
+
+    x = np.zeros_like(gr["x"], dtype=float)
+    if indin[0] != -1:
+        in_mask = det >= 0.0
+        x[in_mask] = a[in_mask] + np.sqrt(det[in_mask])
+    if indout[0] != -1:
+        out_mask = det < 0.0
+        t = np.sqrt(txy2[out_mask])
+        tan_alf = np.tan(alf)
+        x[out_mask] = tan_alf * dsun * t / (tan_alf * t + 1.0)
+
+    qs = {"l": np.float32(0.0), "b": np.float32(0.0), "p": np.float32(0.0), "r": np.float32(rsun), "type": "arc"}
+    return {
+        "x0": x.astype(np.float32),
+        "x1": gr["x"].astype(np.float32),
+        "x2": gr["y"].astype(np.float32),
+        "t0": bz.astype(np.float32),
+        "t1": bx.astype(np.float32),
+        "t2": by.astype(np.float32),
+        "pos": np.asarray(apos, dtype=np.float32),
+        "qs": qs,
+        "ts": dict(qs),
+        "indin": indin,
+        "indout": indout,
+        "visible": idl_where(np.ones_like(x, dtype=bool)),
+        "unvisible": np.int64(-1),
+    }
+
+
+def pex_bl_(si: dict, sh: bool = False, silent: bool = False, bin_value: int | float | None = None, pot_vmag_func=None) -> dict:
+    if pot_vmag_func is None:
+        raise NotImplementedError("pex_bl_ requires pot_vmag_func.")
+
+    s = dict(si)
+    sh_i = 1 if sh else 0
+    bin_i = 0 if bin_value is None else float(bin_value)
+
+    t0 = np.asarray(s["t0"], dtype=float)
+    nx, ny = t0.shape
+    sx = 256.0 if bin_i == 0 else 256.0 / bin_i
+    sy = 256.0 if bin_i == 0 else 256.0 / bin_i
+    npx = max(int(np.ceil(nx / sx)), 10)
+    npy = max(int(np.ceil(ny / sy)), 10)
+    sx = nx / npx
+    sy = ny / npy
+
+    indout_global = np.asarray(s.get("indout", np.array([-1], dtype=np.int64)))
+    if indout_global.size > 0 and indout_global[0] != -1:
+        t0f = t0.ravel()
+        t0f[indout_global.astype(np.int64)] = 0.0
+        t0 = t0f.reshape(t0.shape)
+    s["t0"] = t0
+
+    pot = dict(s)
+    pot["t0"] = np.zeros_like(t0)
+    pot = u_str_add(pot, "t1", np.zeros_like(t0))
+    pot = u_str_add(pot, "t2", np.zeros_like(t0))
+
+    ss_base = u_str_add(dict(s), "t1")
+    ss_base = u_str_add(ss_base, "t2")
+    wgt = np.zeros_like(t0)
+    nparts = 2 * (npx + 2) * (npy + 2)
+    oldcomplete = 0
+
+    for i in range(-1, npx + 1):
+        for j in range(-1, npy + 1):
+            if not silent:
+                complete = int(np.round(100.0 * float(j + 1 + (i + 1) * (npx + 2) + sh_i * nparts / 2.0) / nparts))
+                if (complete > oldcomplete) and (complete % 10 == 0):
+                    print(f"potential field calculating: {complete} % complete")
+                oldcomplete = complete
+
+            xst = min(max(int(i * sx + sx / 2.0 * sh_i), 0), nx - 1)
+            xen = min(max(int((i + 1) * sx - 1.0 + sx / 2.0 * sh_i), 0), nx - 1)
+            yst = min(max(int(j * sy + sy / 2.0 * sh_i), 0), ny - 1)
+            yen = min(max(int((j + 1) * sy - 1.0 + sy / 2.0 * sh_i), 0), ny - 1)
+            if xen < xst or yen < yst:
+                continue
+
+            ss = dict(ss_base)
+            ss = u_str_add(ss, ["t0", "x0", "x1", "x2"], s["t0"][xst:xen + 1, yst:yen + 1], s["x0"][xst:xen + 1, yst:yen + 1], s["x1"][xst:xen + 1, yst:yen + 1], s["x2"][xst:xen + 1, yst:yen + 1])
+            ss["pos"] = np.array([s["x1"][xst, yst], s["x2"][xst, yst], s["x1"][xen, yen], s["x2"][xen, yen]], dtype=float)
+
+            dx = (ss["pos"][2] - ss["pos"][0]) / 2.0 or 1.0
+            dy = (ss["pos"][3] - ss["pos"][1]) / 2.0 or 1.0
+            xc = (ss["pos"][2] + ss["pos"][0]) / 2.0
+            yc = (ss["pos"][3] + ss["pos"][1]) / 2.0
+            wgts = np.exp(-6.0 * ((ss["x1"] - xc) / dx) ** 2 - 6.0 * ((ss["x2"] - yc) / dy) ** 2)
+
+            radius = float(ss["qs"]["r"])
+            alf = radius * np.pi / 180.0 / 3600.0
+            dsun = 1.0 / np.sin(alf)
+            tx = np.tan(ss["x1"] * np.pi / 180.0 / 3600.0)
+            ty = np.tan(ss["x2"] * np.pi / 180.0 / 3600.0)
+            tx2ty2 = tx * tx + ty * ty
+            a = dsun * tx2ty2 / (tx2ty2 + 1.0)
+            b = (dsun * dsun * tx2ty2 - 1.0) / (tx2ty2 + 1.0)
+            det = a * a - b
+            indin = idl_where(det >= 0.0)
+            indout = idl_where(det < 0.0)
+            ss = u_str_add(ss, ["indin", "indout"], indin, indout)
+
+            if indout[0] != -1:
+                t0_local = ss["t0"].ravel()
+                t0_local[indout.astype(np.int64)] = 0.0
+                ss["t0"] = t0_local.reshape(ss["t0"].shape)
+
+            if int(np.sum(np.abs(ss["t0"]) > 0)) != 0 and ss["indin"].size > 1:
+                ss1 = pot_vmag_func(ss, simple=True)
+                if indout[0] != -1 and isinstance(ss1, dict):
+                    for key in ("t0", "t1", "t2"):
+                        arr = np.asarray(ss1[key], dtype=float).ravel()
+                        arr[indout.astype(np.int64)] = 0.0
+                        ss1[key] = arr.reshape(np.asarray(ss1[key]).shape)
+                    wgtsf = wgts.ravel()
+                    wgtsf[indout.astype(np.int64)] = 0.0
+                    wgts = wgtsf.reshape(wgts.shape)
+                if isinstance(ss1, dict):
+                    pot["t0"][xst:xen + 1, yst:yen + 1] = ss1["t0"]
+                    pot["t1"][xst:xen + 1, yst:yen + 1] = ss1["t1"]
+                    pot["t2"][xst:xen + 1, yst:yen + 1] = ss1["t2"]
+                    wgt[xst:xen + 1, yst:yen + 1] = wgts
+
+    s["t0"] = pot["t0"]
+    s["t1"] = pot["t1"]
+    s["t2"] = pot["t2"]
+    s = u_str_add(s, "wgt", wgt)
+    return s
+
+
+def pex_bl(s0: dict, silent: bool = False, pot_vmag_func=None) -> dict:
+    if pot_vmag_func is None:
+        raise NotImplementedError("pex_bl requires pot_vmag_func.")
+
+    t0 = time.time()
+    if not silent:
+        print("starting precise potential field calculating in parts")
+    s1 = pex_bl_(s0, silent=silent, pot_vmag_func=pot_vmag_func)
+    s2 = pex_bl_(s0, sh=True, silent=silent, pot_vmag_func=pot_vmag_func)
+
+    wgt = s1["wgt"] + s2["wgt"]
+    tt0 = s1["t0"] * s1["wgt"] + s2["t0"] * s2["wgt"]
+    tt1 = s1["t1"] * s1["wgt"] + s2["t1"] * s2["wgt"]
+    tt2 = s1["t2"] * s1["wgt"] + s2["t2"] * s2["wgt"]
+
+    ind = idl_where(wgt != 0)
+    if ind[0] != -1:
+        idx = ind.astype(np.int64)
+        fw = wgt.ravel()
+        f0, f1, f2 = tt0.ravel(), tt1.ravel(), tt2.ravel()
+        f0[idx] = f0[idx] / fw[idx]
+        f1[idx] = f1[idx] / fw[idx]
+        f2[idx] = f2[idx] / fw[idx]
+        tt0, tt1, tt2 = f0.reshape(tt0.shape), f1.reshape(tt1.shape), f2.reshape(tt2.shape)
+
+    if not silent:
+        print(f"Potential field calculation complete in {int(round(time.time() - t0))} seconds")
+    return {"t1": tt1, "t2": tt2}
+
+
+def pot_vmag(
+    s: dict,
+    outbpos: dict | None = None,
+    fcenter: int = 1,
+    simple: bool = False,
+    alpha: float = 0.0,
+    normal: bool = True,
+    bpos: dict | None = None,
+    sol_crd_func=None,
+    qs_crd_func=None,
+    a_field_func=None,
+    get_fftplane_func=None,
+    return_outbpos: bool = False,
+):
+    if sol_crd_func is None or qs_crd_func is None or a_field_func is None or get_fftplane_func is None:
+        raise NotImplementedError("pot_vmag requires sol_crd_func, qs_crd_func, a_field_func, and get_fftplane_func.")
+
+    l0, b0, p0 = (0.0, 0.0, 0.0) if normal else (float(s["qs"]["l"]), float(s["qs"]["b"]), float(s["qs"]["p"]))
+    rad = float(s["qs"]["r"])
+    bpos_local = None if bpos is None else dict(bpos)
+
+    if fcenter != 0:
+        indin = np.asarray(s.get("indin", np.array([-1], dtype=np.int64)))
+        if indin.size == 0 or indin[0] == -1:
+            raise ValueError("pot_vmag requires non-empty s['indin'] for fcenter != 0.")
+        idx = indin.astype(np.int64)
+
+        ua = {
+            "x0": np.asarray(s["x0"], dtype=float).ravel()[idx],
+            "x1": np.asarray(s["x1"], dtype=float).ravel()[idx],
+            "x2": np.asarray(s["x2"], dtype=float).ravel()[idx],
+            "qs": {"l": l0, "b": b0, "p": p0, "r": rad, "type": "arc"},
+        }
+        ub = {"qs": dict(ua["qs"])}
+        ub["qs"]["type"] = "dec"
+        u = sol_crd_func(ua, ub, crd=True)
+
+        xc, yc, zc = float(np.mean(u["x0"])), float(np.mean(u["x1"])), float(np.mean(u["x2"]))
+        if fcenter == 2:
+            if "t2" in s and "t1" in s:
+                t0m = np.asarray(s["t0"], dtype=float).ravel()[idx]
+                t1m = np.asarray(s["t1"], dtype=float).ravel()[idx]
+                t2m = np.asarray(s["t2"], dtype=float).ravel()[idx]
+                b_mod = np.sqrt(t0m ** 2 + t1m ** 2 + t2m ** 2)
+            else:
+                b_mod = np.abs(np.asarray(s["t0"], dtype=float).ravel()[idx])
+            denom = float(np.sum(b_mod))
+            yc = float(np.sum(b_mod * np.asarray(u["x1"], dtype=float)) / denom) if denom else yc
+            zc = float(np.sum(b_mod * np.asarray(u["x2"], dtype=float)) / denom) if denom else zc
+            xc = float(np.sqrt(max(0.0, 1.0 - yc ** 2 - zc ** 2)))
+
+        ad = qs_crd_func({"x0": xc, "x1": yc, "x2": zc}, l0, b0, p0, inv=True, tosph=True)
+        lc = float(ad["x2"] * 180.0 / np.pi)
+        bc = float(90.0 - ad["x1"] * 180.0 / np.pi)
+
+        ad = qs_crd_func({"x0": u["x0"], "x1": u["x1"], "x2": u["x2"]}, l0, b0, p0, inv=True)
+        sph = qs_crd_func(ad, lc, bc, 0.0, tosph=True)
+        l = np.asarray(sph["x2"], dtype=float) * 180.0 / np.pi
+        b = 90.0 - np.asarray(sph["x1"], dtype=float) * 180.0 / np.pi
+        hs = np.array([np.max(np.abs(l)), np.max(np.abs(b))], dtype=float)
+
+        rm = np.sqrt(np.asarray(u["x1"], dtype=float) ** 2 + np.asarray(u["x2"], dtype=float) ** 2)
+        srt = np.argsort(rm)[:2]
+        u0 = np.array([u["x0"][srt[0]], u["x1"][srt[0]], u["x2"][srt[0]]], dtype=float)
+        u1 = np.array([u["x0"][srt[1]], u["x1"][srt[1]], u["x2"][srt[1]]], dtype=float)
+        rob0, rob1 = norm_vec(u0), norm_vec(u1)
+        pixs = float(np.arccos(np.clip(float(np.dot(u0, u1) / (rob0 * rob1)), -1.0, 1.0)))
+
+        n_vec = np.maximum(np.fix(2.0 * hs * np.pi / 180.0 / pixs).astype(int), 5)
+        hs = (n_vec - 1) * pixs * 180.0 / np.pi / 2.0
+        bpos_local = {"l": lc, "b": bc, "hs": hs, "n": np.array([n_vec[0], n_vec[1], float(np.min(n_vec)) / 2.0], dtype=float)}
+
+    if bpos_local is None:
+        raise ValueError("bpos must be provided when fcenter == 0.")
+    if outbpos is not None:
+        outbpos.clear()
+        outbpos.update(bpos_local)
+
+    n = np.asarray(bpos_local["n"], dtype=float)[:2].astype(int)
+    hs = np.asarray(bpos_local["hs"], dtype=float)
+    grb = u_grid_box(np.array([-hs[0], -hs[1]], dtype=float), np.array([2.0 * hs[0], 2.0 * hs[1]], dtype=float), n)
+    ph = grb["x"] * np.pi / 180.0
+    th = grb["y"] * np.pi / 180.0
+    r = np.zeros_like(ph)
+
+    sa = {
+        "a": {"x0": s["x0"], "x1": s["x1"], "x2": s["x2"], "t0": s["t0"], "qs": {"l": l0, "b": b0, "p": p0, "r": rad, "type": "arc"}, "pos": s.get("pos")},
+        "b": {"qs": {"l": bpos_local["l"], "b": bpos_local["b"], "p": 0.0, "type": "sbox"}},
+        "proc": "b_spl",
+        "vec": 0,
+    }
+    q = a_field_func(ph, th, r, set=sa)
+    if isinstance(q, dict) and q.get("err"):
+        return 0
+
+    set_obj = {"bl": q["t0"], "spos": {"L": l0, "b": b0, "p": p0}, "bpos": {"l": bpos_local["l"], "b": bpos_local["b"], "hs": hs}, "alfa": alpha}
+    get_fftplane_func(set=set_obj, simple=simple)
+
+    pos = np.array([-hs[0], -hs[1], hs[0], hs[1]], dtype=float) * np.pi / 180.0
+    uu = get_fftplane_func(pos, n, 0.0, simple=simple)
+
+    sa2 = {
+        "a": {"x0": uu["x0"], "x1": uu["x1"], "x2": np.asarray(uu["x0"], dtype=float) * 0.0, "t0": uu["t0"], "t1": uu["t1"], "t2": uu["t2"], "qs": sa["b"]["qs"], "ts": sa["b"]["qs"], "pos": pos},
+        "b": {"qs": sa["a"]["qs"], "ts": sa["a"]["qs"]},
+        "proc": "b_spl",
+        "vec": 1,
+    }
+    q1 = a_field_func(s["x0"], s["x1"], s["x2"], set=sa2)
+
+    s1 = dict(s)
+    s1["t0"] = q1["t0"]
+    s1["t1"] = q1["t1"]
+    s1["t2"] = q1["t2"]
+    s1["type"] = f"vecp {s1['type']}" if "type" in s1 else "vecp"
+    return (s1, bpos_local) if return_outbpos else s1

--- a/pyampp/sfq/step.py
+++ b/pyampp/sfq/step.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import time
+import numpy as np
+
+from .utils import idl_where
+
+
+def sfq_step1(mag: dict, pot: dict, silent: bool = False, acute: bool = False) -> dict:
+    t0 = time.time()
+    if not silent:
+        print("starting preliminary SFQ  disambiguation")
+
+    out = dict(mag)
+    out["t1"] = np.asarray(out["t1"], dtype=float).copy()
+    out["t2"] = np.asarray(out["t2"], dtype=float).copy()
+    p_t1 = np.asarray(pot["t1"], dtype=float)
+    p_t2 = np.asarray(pot["t2"], dtype=float)
+
+    ind = idl_where(out["t2"] < 0)
+    if ind[0] != -1:
+        idx = ind.astype(np.int64)
+        t1f = out["t1"].ravel()
+        t2f = out["t2"].ravel()
+        t1f[idx] = -t1f[idx]
+        t2f[idx] = -t2f[idx]
+        out["t1"] = t1f.reshape(out["t1"].shape)
+        out["t2"] = t2f.reshape(out["t2"].shape)
+
+    if acute:
+        au = out["t1"] * p_t1 + out["t2"] * p_t2
+        ind = idl_where(au < 0)
+        if ind[0] != -1:
+            idx = ind.astype(np.int64)
+            t1f = out["t1"].ravel()
+            t2f = out["t2"].ravel()
+            t1f[idx] = -t1f[idx]
+            t2f[idx] = -t2f[idx]
+            out["t1"] = t1f.reshape(out["t1"].shape)
+            out["t2"] = t2f.reshape(out["t2"].shape)
+        if not silent:
+            print(f"preliminary SFQ  disambiguation complete in {int(round(time.time() - t0))} seconds")
+        return out
+
+    bpy_y = np.roll(p_t1, shift=-1, axis=0) - p_t1
+    by_y = np.roll(out["t1"], shift=-1, axis=0) - out["t1"]
+    au = (bpy_y - by_y) ** 2
+    au_ = (bpy_y + by_y) ** 2
+
+    bpy_y = np.roll(p_t1, shift=-1, axis=1) - p_t1
+    by_y = np.roll(out["t1"], shift=-1, axis=1) - out["t1"]
+    au = au + (bpy_y - by_y) ** 2
+    au_ = au_ + (bpy_y + by_y) ** 2
+
+    bpy_y = np.roll(p_t2, shift=-1, axis=0) - p_t2
+    by_y = np.roll(out["t2"], shift=-1, axis=0) - out["t2"]
+    au = au + (bpy_y - by_y) ** 2
+    au_ = au_ + (bpy_y + by_y) ** 2
+
+    bpy_y = np.roll(p_t2, shift=-1, axis=1) - p_t2
+    by_y = np.roll(out["t2"], shift=-1, axis=1) - out["t2"]
+    au = np.sqrt(au + (bpy_y - by_y) ** 2)
+    au_ = np.sqrt(au_ + (bpy_y + by_y) ** 2)
+
+    ind = idl_where(au > au_)
+    if ind[0] != -1:
+        idx = ind.astype(np.int64)
+        t1f = out["t1"].ravel()
+        t2f = out["t2"].ravel()
+        t1f[idx] = -t1f[idx]
+        t2f[idx] = -t2f[idx]
+        out["t1"] = t1f.reshape(out["t1"].shape)
+        out["t2"] = t2f.reshape(out["t2"].shape)
+
+    if not silent:
+        print(f"preliminary SFQ  disambiguation complete in {int(round(time.time() - t0))} seconds")
+    return out

--- a/pyampp/sfq/utils.py
+++ b/pyampp/sfq/utils.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def idl_where(mask: np.ndarray) -> np.ndarray:
+    """IDL-like WHERE: return flat indices; return [-1] if no match."""
+    idx = np.flatnonzero(mask)
+    if idx.size == 0:
+        return np.array([-1], dtype=np.int64)
+    return idx.astype(np.int64)
+
+
+def u_grid(pos: np.ndarray, n: tuple[int, int]) -> dict[str, np.ndarray]:
+    """Build an IDL-like pixel grid centered at ``pos``."""
+    if len(n) != 2:
+        raise ValueError("n must be a 2-element shape tuple.")
+    if np.asarray(pos).size != 2:
+        raise ValueError("pos must have 2 elements.")
+    x0, y0 = float(pos[0]), float(pos[1])
+    ii, jj = np.indices((int(n[0]), int(n[1])), dtype=float)
+    return {"x": ii - x0, "y": jj - y0}
+
+
+def u_grid_box(start: np.ndarray, extent: np.ndarray, n: np.ndarray) -> dict[str, np.ndarray]:
+    """Build a regular 2D grid from start/extents/sample counts."""
+    start = np.asarray(start, dtype=float).reshape(2)
+    extent = np.asarray(extent, dtype=float).reshape(2)
+    n = np.asarray(n, dtype=int).reshape(2)
+    nx, ny = int(n[0]), int(n[1])
+    if nx < 2 or ny < 2:
+        raise ValueError("grid dimensions must be >= 2 in both axes.")
+    x = start[0] + np.arange(nx, dtype=float) * extent[0] / float(nx - 1)
+    y = start[1] + np.arange(ny, dtype=float) * extent[1] / float(ny - 1)
+    xx, yy = np.meshgrid(x, y, indexing="ij")
+    return {"x": xx, "y": yy}
+
+
+def u_str_add(s: dict, tags, *values):
+    """Minimal IDL-like struct tag add/update helper."""
+    out = dict(s)
+    if isinstance(tags, (list, tuple, np.ndarray)):
+        if len(values) != len(tags):
+            raise ValueError("When tags is a sequence, values length must match tags length.")
+        for k, v in zip(tags, values):
+            out[str(k)] = v
+        return out
+
+    key = str(tags)
+    if len(values) == 0:
+        if "t0" in out and isinstance(out["t0"], np.ndarray):
+            out[key] = np.zeros_like(out["t0"])
+        else:
+            out[key] = None
+    else:
+        out[key] = values[0]
+    return out
+
+
+def norm_vec(v: np.ndarray) -> float:
+    return float(np.sqrt(np.sum(np.asarray(v, dtype=float) ** 2)))

--- a/pyampp/tests/build_h5_from_sav.py
+++ b/pyampp/tests/build_h5_from_sav.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Dict, Tuple
+
+try:
+    import h5py
+except Exception as exc:  # pragma: no cover - ad-hoc script
+    print("Missing dependency: h5py. Install with `python -m pip install h5py`.", file=sys.stderr)
+    raise SystemExit(1) from exc
+
+try:
+    import numpy as np
+except Exception as exc:  # pragma: no cover - ad-hoc script
+    print("Missing dependency: numpy. Install with `python -m pip install numpy`.", file=sys.stderr)
+    raise SystemExit(1) from exc
+
+try:
+    from scipy.io import readsav
+except Exception as exc:  # pragma: no cover - ad-hoc script
+    print("Missing dependency: scipy. Install with `python -m pip install scipy`.", file=sys.stderr)
+    raise SystemExit(1) from exc
+
+
+IDL_TO_H5 = {
+    "DR": "chromo/dr",
+    "STARTIDX": "chromo/start_idx",
+    "ENDIDX": "chromo/end_idx",
+    "AVFIELD": "chromo/av_field",
+    "PHYSLENGTH": "chromo/phys_length",
+    "BCUBE": "chromo/bcube",
+    "CHROMO_IDX": "chromo/chromo_idx",
+    "CHROMO_BCUBE": "chromo/chromo_bcube",
+    "N_HTOT": "chromo/n_htot",
+    "N_HI": "chromo/n_hi",
+    "N_P": "chromo/n_p",
+    "DZ": "chromo/dz",
+    "CHROMO_N": "chromo/chromo_n",
+    "CHROMO_T": "chromo/chromo_t",
+    "CHROMO_LAYERS": "chromo/chromo_layers",
+    "TR": "chromo/tr",
+    "TR_H": "chromo/tr_h",
+    "CORONA_BASE": "chromo/corona_base",
+}
+
+
+def _load_box(sav_path: str):
+    data = readsav(sav_path, verbose=False)
+    if "box" not in data:
+        raise ValueError("IDL .sav does not contain a 'box' variable.")
+    return data["box"].flat[0]
+
+
+def _prepare_array(idl_val, h5_shape: Tuple[int, ...], *, field_name: str) -> np.ndarray:
+    arr = np.asarray(idl_val)
+    if arr.shape == h5_shape:
+        return arr
+
+    # Flatten 3D to 1D (same size)
+    if arr.ndim == 3 and len(h5_shape) == 1 and arr.size == int(np.prod(h5_shape)):
+        return arr.reshape(h5_shape)
+
+    # Move vector axis from first to last (IDL: (3, X, Y, Z) -> H5: (X, Y, Z, 3))
+    if arr.ndim == 4 and len(h5_shape) == 4:
+        if arr.shape[0] == h5_shape[-1] and arr.shape[1:] == h5_shape[:3]:
+            return np.moveaxis(arr, 0, -1)
+
+    # Reorder DZ: IDL (Z, X, Y) -> H5 (X, Y, Z)
+    if arr.ndim == 3 and len(h5_shape) == 3 and arr.shape[::-1] == h5_shape:
+        return np.transpose(arr, (1, 2, 0))
+
+    if arr.size == int(np.prod(h5_shape)):
+        return arr.reshape(h5_shape)
+
+    # Handle 1D length mismatch by truncating to match HDF5 target
+    if arr.ndim == 1 and len(h5_shape) == 1:
+        if arr.size > h5_shape[0]:
+            print(
+                f"Warning: truncating {field_name} from {arr.size} to {h5_shape[0]} elements.",
+                file=sys.stderr,
+            )
+            return arr[: h5_shape[0]]
+        if arr.size < h5_shape[0]:
+            raise ValueError(
+                f"{field_name} has {arr.size} elements, smaller than HDF5 target {h5_shape[0]}."
+            )
+
+    raise ValueError(f"Cannot reshape IDL array {arr.shape} to HDF5 shape {h5_shape}.")
+
+
+def _collect_idl_arrays(box) -> Dict[str, np.ndarray]:
+    arrays = {}
+    for idl_field, _ in IDL_TO_H5.items():
+        arrays[idl_field] = box[idl_field]
+    return arrays
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create a pyAMPP-style HDF5 by copying a template and filling with IDL .sav data."
+    )
+    parser.add_argument("--template", required=True, help="Path to existing pyAMPP HDF5 template.")
+    parser.add_argument("--sav", required=True, help="Path to IDL .sav file containing BOX.")
+    parser.add_argument("--out", required=True, help="Output HDF5 path.")
+    args = parser.parse_args()
+
+    box = _load_box(args.sav)
+    idl_arrays = _collect_idl_arrays(box)
+
+    # Copy template to output (copy each top-level object)
+    with h5py.File(args.template, "r") as src, h5py.File(args.out, "w") as dst:
+        for name in src.keys():
+            src.copy(name, dst)
+
+    # Fill datasets in output
+    with h5py.File(args.out, "r+") as f:
+        for idl_field, h5_path in IDL_TO_H5.items():
+            if h5_path not in f:
+                print(f"Skip missing HDF5 dataset: {h5_path}", file=sys.stderr)
+                continue
+            ds = f[h5_path]
+            arr = _prepare_array(idl_arrays[idl_field], ds.shape, field_name=idl_field)
+            ds[...] = arr
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyampp/tests/compare_idl_hdf5.py
+++ b/pyampp/tests/compare_idl_hdf5.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+try:
+    import h5py
+except Exception as exc:  # pragma: no cover - ad-hoc script
+    print("Missing dependency: h5py. Install with `python -m pip install h5py`.", file=sys.stderr)
+    raise SystemExit(1) from exc
+
+try:
+    import numpy as np
+except Exception as exc:  # pragma: no cover - ad-hoc script
+    print("Missing dependency: numpy. Install with `python -m pip install numpy`.", file=sys.stderr)
+    raise SystemExit(1) from exc
+
+try:
+    from scipy.io import readsav
+except Exception as exc:  # pragma: no cover - ad-hoc script
+    print("Missing dependency: scipy. Install with `python -m pip install scipy`.", file=sys.stderr)
+    raise SystemExit(1) from exc
+
+
+CHR_IDL_TO_H5 = {
+    "DR": "chromo/dr",
+    "STARTIDX": "chromo/start_idx",
+    "ENDIDX": "chromo/end_idx",
+    "AVFIELD": "chromo/av_field",
+    "PHYSLENGTH": "chromo/phys_length",
+    "BCUBE": "chromo/bcube",
+    "CHROMO_IDX": "chromo/chromo_idx",
+    "CHROMO_BCUBE": "chromo/chromo_bcube",
+    "N_HTOT": "chromo/n_htot",
+    "N_HI": "chromo/n_hi",
+    "N_P": "chromo/n_p",
+    "DZ": "chromo/dz",
+    "CHROMO_N": "chromo/chromo_n",
+    "CHROMO_T": "chromo/chromo_t",
+    "CHROMO_LAYERS": "chromo/chromo_layers",
+    "TR": "chromo/tr",
+    "TR_H": "chromo/tr_h",
+    "CORONA_BASE": "chromo/corona_base",
+}
+
+NAS_IDL_TO_H5 = {
+    "BX": "corona/bx",
+    "BY": "corona/by",
+    "BZ": "corona/bz",
+}
+
+POT_IDL_TO_H5 = {
+    "BX": "corona/bx",
+    "BY": "corona/by",
+    "BZ": "corona/bz",
+}
+
+
+@dataclass
+class FieldInfo:
+    shape: Tuple[int, ...]
+    dtype: str
+
+
+def _h5_fields(path: str) -> Dict[str, FieldInfo]:
+    fields: Dict[str, FieldInfo] = {}
+    with h5py.File(path, "r") as f:
+        for group in f.keys():
+            for name, obj in f[group].items():
+                if isinstance(obj, h5py.Dataset):
+                    fields[f"{group}/{name}"] = FieldInfo(obj.shape, str(obj.dtype))
+    return fields
+
+
+def _load_idl_box(data: Dict[str, Any]):
+    if "box" in data:
+        return data["box"].flat[0]
+    if "pbox" in data:
+        return data["pbox"].flat[0]
+    raise KeyError("No 'box' or 'pbox' found in SAV file.")
+
+
+def _sav_fields(path: str) -> Dict[str, FieldInfo]:
+    data = readsav(path, verbose=False)
+    box = _load_idl_box(data)
+    fields: Dict[str, FieldInfo] = {}
+    for field in box.dtype.names:
+        val = box[field]
+        if isinstance(val, np.ndarray):
+            fields[field] = FieldInfo(val.shape, str(val.dtype))
+        else:
+            fields[field] = FieldInfo((), type(val).__name__)
+    return fields
+
+
+def _sav_base_fields(path: str) -> Dict[str, FieldInfo]:
+    data = readsav(path, verbose=False)
+    box = _load_idl_box(data)
+    base = box["BASE"]
+    fields: Dict[str, FieldInfo] = {}
+    if isinstance(base, np.ndarray) and base.size:
+        b0 = base.flat[0]
+        for field in base.dtype.names:
+            val = b0[field]
+            if isinstance(val, np.ndarray):
+                fields[field] = FieldInfo(val.shape, str(val.dtype))
+            else:
+                fields[field] = FieldInfo((), type(val).__name__)
+    return fields
+
+
+def _note_shape(idl_shape: Tuple[int, ...], h5_shape: Tuple[int, ...]) -> str:
+    if idl_shape == h5_shape:
+        return ""
+    if int(np.prod(idl_shape)) == int(np.prod(h5_shape)) and len(idl_shape) == 3 and len(h5_shape) == 1:
+        return "flattened in HDF5"
+    if len(idl_shape) == 4 and len(h5_shape) == 4 and sorted(idl_shape) == sorted(h5_shape):
+        return "axis order differs"
+    if len(idl_shape) == 3 and len(h5_shape) == 3 and sorted(idl_shape) == sorted(h5_shape):
+        return "axis order differs"
+    if int(np.prod(idl_shape)) == int(np.prod(h5_shape)):
+        return "same size, different shape"
+    return "shape differs"
+
+def _infer_stage(h5_fields: Dict[str, FieldInfo], sav_fields: Dict[str, FieldInfo]) -> str:
+    h5_keys = set(h5_fields.keys())
+    if any(k.startswith("chromo/") for k in h5_keys):
+        return "chr"
+    if any(k.startswith("corona/") for k in h5_keys):
+        return "nas"
+    if any(k.startswith("nlfff/") for k in h5_keys):
+        return "nas"
+    if any(k.startswith("pot/") for k in h5_keys):
+        return "pot"
+    # Fallback to IDL fields if HDF5 is minimal
+    if "BX" in sav_fields and "BY" in sav_fields and "BZ" in sav_fields:
+        return "nas"
+    return "unknown"
+
+def _mapping_for_stage(stage: str) -> Dict[str, str]:
+    if stage == "chr":
+        return CHR_IDL_TO_H5
+    if stage == "nas":
+        return NAS_IDL_TO_H5
+    if stage == "pot":
+        return POT_IDL_TO_H5
+    return {}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compare IDL .sav BOX fields to HDF5 datasets.")
+    parser.add_argument("--h5", required=True, help="Path to HDF5 file.")
+    parser.add_argument("--sav", required=True, help="Path to IDL .sav file.")
+    parser.add_argument("--out", help="Write JSON report to this path.")
+    parser.add_argument("--stage", choices=["auto", "nas", "pot", "chr"], default="auto",
+                        help="Stage mapping to use (default: auto-detect).")
+    args = parser.parse_args()
+
+    h5_fields = _h5_fields(args.h5)
+    sav_fields = _sav_fields(args.sav)
+    base_fields = _sav_base_fields(args.sav)
+
+    stage = _infer_stage(h5_fields, sav_fields) if args.stage == "auto" else args.stage
+    mapping_table = _mapping_for_stage(stage)
+
+    mapping: List[Dict[str, Any]] = []
+    for idl_field, h5_path in mapping_table.items():
+        idl = sav_fields.get(idl_field)
+        h5 = h5_fields.get(h5_path)
+        note = ""
+        if idl and h5:
+            note = _note_shape(idl.shape, h5.shape)
+        mapping.append(
+            {
+                "idl_field": idl_field,
+                "h5_path": h5_path,
+                "idl_shape": idl.shape if idl else None,
+                "h5_shape": h5.shape if h5 else None,
+                "idl_dtype": idl.dtype if idl else None,
+                "h5_dtype": h5.dtype if h5 else None,
+                "note": note,
+            }
+        )
+
+    h5_only = sorted(set(h5_fields.keys()) - set(mapping_table.values()))
+    idl_only = sorted(set(sav_fields.keys()) - set(mapping_table.keys()))
+
+    report = {
+        "stage": stage,
+        "mapping": mapping,
+        "hdf5_only": {k: h5_fields[k].__dict__ for k in h5_only},
+        "idl_only": {k: sav_fields[k].__dict__ for k in idl_only},
+        "idl_base_fields": {k: v.__dict__ for k, v in base_fields.items()},
+    }
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, default=str)
+    else:
+        print(json.dumps(report, indent=2, default=str))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyampp/tests/idl_hdf5_mapping.md
+++ b/pyampp/tests/idl_hdf5_mapping.md
@@ -1,0 +1,66 @@
+# IDL .sav ↔ HDF5 mapping (b3d_data_20240512T000000_dim64x64x64)
+
+Files compared
+- IDL .sav: `/Users/gelu/gx_models/2024-05-12/hmi.M_720s.20240511_235843.E73S3CR.CEA.NAS.CHR.sav`
+- HDF5: `/Users/gelu/pyampp/gx_models/b3d_data_20240512T000000_dim64x64x64.h5`
+
+## Field-by-field mapping
+
+| IDL BOX field | HDF5 dataset | IDL shape | HDF5 shape | Notes |
+| --- | --- | --- | --- | --- |
+| `DR` | `chromo/dr` | (3,) | (3,) |  |
+| `STARTIDX` | `chromo/start_idx` | (64,64,64) | (262144,) | flattened in HDF5 |
+| `ENDIDX` | `chromo/end_idx` | (64,64,64) | (262144,) | flattened in HDF5 |
+| `AVFIELD` | `chromo/av_field` | (64,64,64) | (262144,) | flattened in HDF5 |
+| `PHYSLENGTH` | `chromo/phys_length` | (64,64,64) | (262144,) | flattened in HDF5 |
+| `BCUBE` | `chromo/bcube` | (3,64,64,64) | (64,64,64,3) | axis order differs |
+| `CHROMO_IDX` | `chromo/chromo_idx` | (328170,) | (328090,) | length differs |
+| `CHROMO_BCUBE` | `chromo/chromo_bcube` | (3,90,64,64) | (64,64,90,3) | axis order differs |
+| `N_HTOT` | `chromo/n_htot` | (328170,) | (328090,) | length differs |
+| `N_HI` | `chromo/n_hi` | (328170,) | (328090,) | length differs |
+| `N_P` | `chromo/n_p` | (328170,) | (328090,) | length differs |
+| `DZ` | `chromo/dz` | (152,64,64) | (64,64,152) | axis order differs |
+| `CHROMO_N` | `chromo/chromo_n` | (328170,) | (328090,) | length differs |
+| `CHROMO_T` | `chromo/chromo_t` | (328170,) | (328090,) | length differs |
+| `CHROMO_LAYERS` | `chromo/chromo_layers` | () | () |  |
+| `TR` | `chromo/tr` | (64,64) | (64,64) |  |
+| `TR_H` | `chromo/tr_h` | (64,64) | (64,64) |  |
+| `CORONA_BASE` | `chromo/corona_base` | () | () |  |
+
+## HDF5-only datasets (not present in IDL BOX)
+
+- `chromo/apex_idx`
+- `chromo/codes`
+- `chromo/seed_idx`
+- `chromo/voxel_status`
+- `chromo/chromo_mask` (IDL equivalent appears as `BOX.BASE.CHROMO_MASK`)
+- `corona/bx`, `corona/by`, `corona/bz` (3D field cubes, `model_type` attr indicates POT/NLFFF)
+
+## IDL-only BOX fields (not present in HDF5)
+
+- `ADD_BASE_LAYER`
+- `STATUS` (64,64,64 uint8)
+- `ID`
+- `EXECUTE`
+- `INDEX` (WCS/observation metadata)
+- `REFMAPS` (IDL object metadata)
+- `BASE` (struct with 2D fields)
+  - `BX`, `BY`, `BZ` (64,64)
+  - `IC` (64,64)
+  - `CHROMO_MASK` (64,64)
+
+## Metadata differences
+
+- HDF5 `chromo` group attributes: `dsun_obs`, `lat`, `lon`, `obs_time`
+- IDL `INDEX` includes WCS, pointing, and history/comment fields not present as HDF5 attrs.
+
+## Regeneration
+
+Use the script in `pyampp/tests/compare_idl_hdf5.py` to generate a JSON report:
+
+```bash
+python pyampp/tests/compare_idl_hdf5.py \
+  --h5 /Users/gelu/pyampp/gx_models/b3d_data_20240512T000000_dim64x64x64.h5 \
+  --sav /Users/gelu/gx_models/2024-05-12/hmi.M_720s.20240511_235843.E73S3CR.CEA.NAS.CHR.sav \
+  --out /tmp/idl_hdf5_report.json
+```

--- a/pyampp/tests/idl_parity_notes.md
+++ b/pyampp/tests/idl_parity_notes.md
@@ -1,0 +1,97 @@
+# IDL Parity Notes (2024-05-12 run)
+
+This note summarizes code changes and comparison results performed to align Python outputs with the IDL `gx_fov2box` pipeline.
+
+## Scope
+- Target: match IDL base maps (BX/BY/BZ/IC) and chromo mask distribution.
+- Data: 2024-05-12 run
+  - Python H5: `/Users/gelu/pyampp/gx_models/2024-05-12/hmi.M_720s.20240512_000000.E73S03CR.CEA.NONE.h5`
+  - IDL SAV: `/Users/gelu/gx_models/2024-05-12/hmi.M_720s.20240511_235843.E73S3CR.CEA.NONE.sav`
+
+## Code Changes
+### Reprojection parity (IDL `/ssaa`)
+- Switched `reproject_to` algorithm to `"exact"` (flux‑conserving) across:
+  - `pyampp/gxbox/gx_fov2box.py`
+  - `pyampp/gxbox/gxbox_factory.py`
+  - `pyampp/util/compute.py`
+- Removed `roundtrip_coords=False` where it was passed to `reproject_exact`.
+
+### HMI disambiguation parity
+- IDL uses `hmi_disambig, ..., 0`.
+- Python now calls `hmi_disambig(..., method=0)` in `pyampp/gxbox/gx_fov2box.py`.
+
+### Component mapping parity
+- IDL base convention: `BX=BP`, `BY=-BT`, `BZ=BR`.
+- Applied in:
+  - `pyampp/gxbox/gx_fov2box.py`
+  - `pyampp/gxbox/gxbox_factory.py` (base map paths + NLFFF boundary seed map)
+
+### RSUN parity
+- IDL sets `WCS_RSUN=6.96e8` for coordinate transforms.
+- Python now preserves `rsun_ref=6.96e8` in `hmi_b2ptr` output maps:
+  - `pyampp/gxbox/boxutils.py`
+  - `pyampp/util/compute.py`
+
+### CEA origin parity
+- IDL CEA uses Carrington lon/lat by default.
+- `pyampp/gxbox/box.py`: bottom CEA header now uses `HeliographicCarrington` origin.
+
+### Full‑map remap parity (no pre‑submap)
+- IDL remaps from full input maps (not pre‑cropped).
+- `pyampp/gxbox/gx_fov2box.py` updated to reproject base maps from full‑resolution maps.
+
+### Decompose NaN handling
+- Full‑map reprojection introduced NaNs in base maps.
+- `pyampp/gx_chromo/decompose.py` now ignores NaNs when building histograms.
+
+## Run/Command Notes
+- Local run example (avoids JSOC downloads):
+  ```bash
+  env SUNPY_CONFIGDIR=/tmp/sunpy MPLCONFIGDIR=/tmp/mplconfig \
+    /Users/gelu/miniforge3/envs/suncast/bin/python -m pyampp.gxbox.gx_fov2box \
+    --time 2024-05-12T00:00:00 --coords 0 0 --hpc \
+    --box-dims 64 64 64 --dx-km 1400.000 --pad-frac 0.10 \
+    --data-dir /Users/gelu/pyampp/download --gxmodel-dir /Users/gelu/pyampp/gx_models \
+    --euv --uv --save-empty-box --save-potential --save-bounds --local-only
+  ```
+
+## Comparison Results (Latest)
+### Base Map Statistics (H5 vs IDL)
+- **BX**
+  - H5 min/max/mean: `-42.1516 / 45.6700 / -0.2907`
+  - IDL min/max/mean: `-79.9754 / 80.9864 / 2.0924`
+  - Diff (H5–IDL) absmax: `88.1449`
+- **BY**
+  - H5 min/max/mean: `-53.6737 / 57.2337 / -0.3542`
+  - IDL min/max/mean: `-81.0593 / 67.6691 / 0.5290`
+  - Diff (H5–IDL) absmax: `104.1693`
+- **BZ**
+  - H5 min/max/mean: `-118.6402 / 156.0102 / 0.5628`
+  - IDL min/max/mean: `-200.1001 / 275.9383 / 0.5140`
+  - Diff (H5–IDL) absmax: `119.9281`
+- **IC**
+  - H5 min/max/mean: `0.969339 / 1.039488 / 1.003992`
+  - IDL min/max/mean: `0.949106 / 1.062015 / 1.003984`
+  - Diff (H5–IDL) absmax: `0.02854`
+
+### Chroma Mask Histogram (H5 vs IDL‑derived)
+IDL `chromo_mask` is not stored in NONE `.sav`, so it was recomputed from IDL `BASE.BZ/IC` using the same `decompose()`:
+
+```
+Value  H5_count  IDL_count  diff
+    1      3032       3007     25
+    2       862        866     -4
+    3       113        119     -6
+    4        57         55      2
+    5        32         49    -17
+```
+
+- Mismatched pixels: **628 / 4096**
+- Diff map: `pyampp/tests/chromo_mask_diff.png`
+
+## Open Issues / Next Steps
+1. Base Bx/By/Bz still differ significantly vs IDL.
+2. Full‑map reprojection produced NaNs at edges; decompose handles it but may still affect class assignments.
+3. Need to verify whether the latest run used the updated full‑map remap code or older path (execute string in H5 does not encode code version).
+4. Optional: compare mismatch spatial distribution and investigate if differences cluster by mask class or near edges.
+

--- a/pyampp/tests/idl_stage_report.py
+++ b/pyampp/tests/idl_stage_report.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+import numpy as np
+from scipy.io import readsav
+
+
+STAGE_ORDER = ["NONE", "POT", "BND", "NAS", "GEN", "CHR"]
+
+
+def stage_from_name(path: Path) -> str:
+    name = path.name
+    for stage in reversed(STAGE_ORDER):
+        if f".{stage}." in name or name.endswith(f".{stage}.sav"):
+            return stage
+    return "UNKNOWN"
+
+
+def get_box(data: dict) -> tuple[str | None, Any | None]:
+    if "box" in data:
+        return "box", data["box"].flat[0]
+    if "pbox" in data:
+        return "pbox", data["pbox"].flat[0]
+    return None, None
+
+
+def field_info(val: Any) -> Dict[str, Any]:
+    if isinstance(val, np.ndarray) and val.dtype.names:
+        return {"type": "struct", "shape": list(val.shape), "fields": list(val.dtype.names)}
+    if isinstance(val, np.ndarray):
+        return {"type": "array", "shape": list(val.shape), "dtype": str(val.dtype)}
+    return {"type": "scalar", "dtype": type(val).__name__}
+
+
+def struct_fields(val: Any) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    if isinstance(val, np.ndarray) and val.dtype.names and val.size:
+        v0 = val.flat[0]
+        for f in val.dtype.names:
+            out[f] = field_info(v0[f])
+    return out
+
+
+def summarize_box(box: Any) -> Dict[str, Any]:
+    fields: Dict[str, Any] = {}
+    for field in box.dtype.names:
+        info = field_info(box[field])
+        if info["type"] == "struct":
+            info["members"] = struct_fields(box[field])
+        fields[field] = info
+    return fields
+
+
+def diff_fields(prev: Dict[str, Any], curr: Dict[str, Any]) -> Dict[str, Any]:
+    prev_keys = set(prev.keys())
+    curr_keys = set(curr.keys())
+    added = sorted(curr_keys - prev_keys)
+    removed = sorted(prev_keys - curr_keys)
+    changed = []
+    for k in sorted(curr_keys & prev_keys):
+        if prev[k] != curr[k]:
+            changed.append(k)
+    return {"added": added, "removed": removed, "changed": changed}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate a JSON report for IDL AMPP stage .sav files.")
+    parser.add_argument("--dir", required=True, help="Directory containing .sav stage files.")
+    parser.add_argument("--out", required=True, help="Output JSON file.")
+    args = parser.parse_args()
+
+    folder = Path(args.dir)
+    files = sorted(folder.glob("*.sav"))
+    files = sorted(
+        files,
+        key=lambda p: STAGE_ORDER.index(stage_from_name(p)) if stage_from_name(p) in STAGE_ORDER else 99,
+    )
+
+    report: Dict[str, Any] = {"stages": []}
+    prev_fields = None
+    prev_stage = None
+
+    for path in files:
+        data = readsav(str(path), verbose=False)
+        box_name, box = get_box(data)
+        entry: Dict[str, Any] = {
+            "file": path.name,
+            "stage": stage_from_name(path),
+            "box_name": box_name,
+        }
+        if box is None:
+            entry["error"] = "no_box_or_pbox"
+            report["stages"].append(entry)
+            continue
+        fields = summarize_box(box)
+        entry["fields"] = fields
+        if prev_fields is not None:
+            entry["diff_from_prev"] = diff_fields(prev_fields, fields)
+            entry["prev_stage"] = prev_stage
+        report["stages"].append(entry)
+        prev_fields = fields
+        prev_stage = entry["stage"]
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyampp/tests/run_amp_stages_cli.py
+++ b/pyampp/tests/run_amp_stages_cli.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 from pathlib import Path
 from typing import Dict, Any
@@ -16,7 +15,6 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
-from sunpy.coordinates import frames
 import sunpy.map
 from sunpy.sun import constants as sun_consts
 from sunpy.map import all_coordinates_from_map
@@ -43,7 +41,7 @@ def cutout2box(_map, center_crd: SkyCoord, dx_km, shape):
     box_header = sunpy.map.make_fitswcs_header(shape, origin,
                                                projection_code='CEA', scale=scale)
 
-    outmap = _map.reproject_to(box_header, algorithm="adaptive", roundtrip_coords=False)
+    outmap = _map.reproject_to(box_header, algorithm="exact")
     return outmap
 
 

--- a/pyampp/tests/run_amp_stages_cli.py
+++ b/pyampp/tests/run_amp_stages_cli.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Dict, Any
+
+# Ensure repo root is on sys.path for direct script execution
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from astropy.time import Time
+from sunpy.coordinates import frames
+import sunpy.map
+from sunpy.sun import constants as sun_consts
+from sunpy.map import all_coordinates_from_map
+import h5py
+
+from pyAMaFiL.mag_field_proc import MagFieldProcessor
+from pyAMaFiL.mag_field_lin_fff import MagFieldLinFFF
+
+from pyampp.gx_chromo.combo_model import combo_model
+
+
+def cutout2box(_map, center_crd: SkyCoord, dx_km, shape):
+    center_crd = center_crd.transform_to("heliographic_carrington")
+    lon = center_crd.lon
+    lat = center_crd.lat
+    rad = center_crd.radius
+    origin = SkyCoord(lon, lat, rad,
+                      frame="heliographic_carrington",
+                      observer="self",
+                      obstime=_map.date)
+
+    scale = np.arcsin(dx_km / origin.radius).to(u.deg) / u.pix
+    scale = u.Quantity((scale, scale))
+    box_header = sunpy.map.make_fitswcs_header(shape, origin,
+                                               projection_code='CEA', scale=scale)
+
+    outmap = _map.reproject_to(box_header, algorithm="adaptive", roundtrip_coords=False)
+    return outmap
+
+
+def hmi_b2ptr(map_field, map_inclination, map_azimuth):
+    sz = map_field.data.shape
+    ny, nx = sz
+
+    field = map_field.data
+    gamma = np.deg2rad(map_inclination.data)
+    psi = np.deg2rad(map_azimuth.data)
+
+    b_xi = -field * np.sin(gamma) * np.sin(psi)
+    b_eta = field * np.sin(gamma) * np.cos(psi)
+    b_zeta = field * np.cos(gamma)
+
+    foo = all_coordinates_from_map(map_field).transform_to("heliographic_stonyhurst")
+    phi = foo.lon
+    lambda_ = foo.lat
+
+    b = np.deg2rad(map_field.fits_header["crlt_obs"])
+    p = np.deg2rad(-map_field.fits_header["crota2"])
+
+    phi, lambda_ = np.deg2rad(phi), np.deg2rad(lambda_)
+
+    sinb, cosb = np.sin(b), np.cos(b)
+    sinp, cosp = np.sin(p), np.cos(p)
+    sinphi, cosphi = np.sin(phi), np.cos(phi)
+    sinlam, coslam = np.sin(lambda_), np.cos(lambda_)
+
+    k11 = coslam * (sinb * sinp * cosphi + cosp * sinphi) - sinlam * cosb * sinp
+    k12 = - coslam * (sinb * cosp * cosphi - sinp * sinphi) + sinlam * cosb * cosp
+    k13 = coslam * cosb * cosphi + sinlam * sinb
+    k21 = sinlam * (sinb * sinp * cosphi + cosp * sinphi) + coslam * cosb * sinp
+    k22 = - sinlam * (sinb * cosp * cosphi - sinp * sinphi) - coslam * cosb * cosp
+    k23 = sinlam * cosb * cosphi - coslam * sinb
+    k31 = - sinb * sinp * sinphi + cosp * cosphi
+    k32 = sinb * cosp * sinphi + sinp * cosphi
+    k33 = - cosb * sinphi
+
+    bptr = np.zeros((3, nx, ny))
+
+    bptr[0, :, :] = k31 * b_xi + k32 * b_eta + k33 * b_zeta
+    bptr[1, :, :] = k21 * b_xi + k22 * b_eta + k23 * b_zeta
+    bptr[2, :, :] = k11 * b_xi + k12 * b_eta + k13 * b_zeta
+
+    header = map_field.fits_header
+    map_bp = sunpy.map.Map(bptr[0, :, :], header)
+    map_bt = sunpy.map.Map(bptr[1, :, :], header)
+    map_br = sunpy.map.Map(bptr[2, :, :], header)
+
+    return map_bp, map_bt, map_br
+
+
+def write_b3d_h5(filename: str, box_b3d: dict):
+    with h5py.File(filename, "w") as hdf_file:
+        for model_type, components in box_b3d.items():
+            if components is None:
+                continue
+            if model_type == "metadata":
+                group = hdf_file.create_group("metadata")
+                for key, value in components.items():
+                    if isinstance(value, str):
+                        group.create_dataset(key, data=np.string_(value))
+                    else:
+                        group.create_dataset(key, data=value)
+                continue
+            group = hdf_file.create_group(model_type)
+            for component, data in components.items():
+                if component == "attrs":
+                    group.attrs.update(data)
+                else:
+                    if model_type == "chromo" and component == "voxel_status":
+                        group.create_dataset(component, data=np.asarray(data, dtype=np.uint8))
+                    else:
+                        group.create_dataset(component, data=data)
+
+
+def build_coord_tag(lon_deg: float, lat_deg: float) -> str:
+    lon = (lon_deg + 180.0) % 360.0 - 180.0
+    lon_dir = "W" if lon >= 0 else "E"
+    lat_dir = "N" if lat_deg >= 0 else "S"
+    lon_val = f"{abs(int(round(lon))):02d}"
+    lat_val = f"{abs(int(round(lat_deg))):02d}"
+    return f"{lon_dir}{lon_val}{lat_dir}{lat_val}CR"
+
+
+def make_out_dir(gxmodel_dir: str, obs_time: Time) -> Path:
+    date_str = obs_time.to_datetime().strftime("%Y-%m-%d")
+    out_dir = Path(gxmodel_dir) / date_str
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def stage_filename(out_dir: Path, obs_time: Time, coord_tag: str, stage: str) -> Path:
+    time_tag = obs_time.to_datetime().strftime("%Y%m%d_%H%M%S")
+    base = f"hmi.M_720s.{time_tag}.{coord_tag}.CEA"
+    return out_dir / f"{base}.{stage}.h5"
+
+
+def load_hmi_maps(data_dir: Path) -> Dict[str, sunpy.map.Map]:
+    field_path = list(data_dir.glob("*.field.fits"))[0]
+    incli_path = list(data_dir.glob("*.inclination.fits"))[0]
+    azimu_path = list(data_dir.glob("*.azimuth.fits"))[0]
+    disam_path = list(data_dir.glob("*.disambig.fits"))[0]
+    conti_path = list(data_dir.glob("*.continuum.fits"))[0]
+    losma_path = list(data_dir.glob("*.magnetogram.fits"))[0]
+
+    map_field = sunpy.map.Map(field_path)
+    map_inclination = sunpy.map.Map(incli_path)
+    map_azimuth = sunpy.map.Map(azimu_path)
+    map_disambig = sunpy.map.Map(disam_path)
+    map_conti = sunpy.map.Map(conti_path)
+    map_losma = sunpy.map.Map(losma_path)
+
+    dis = map_disambig.data
+    map_azimuth.data[:, :] = map_azimuth.data + dis * 180.0
+
+    return {
+        "field": map_field,
+        "inclination": map_inclination,
+        "azimuth": map_azimuth,
+        "disambig": map_disambig,
+        "continuum": map_conti,
+        "magnetogram": map_losma,
+    }
+
+
+def build_header(map_field: sunpy.map.Map) -> Dict[str, Any]:
+    header_field = map_field.wcs.to_header()
+    field_frame = map_field.center.heliographic_carrington.frame
+    lon, lat = field_frame.lon.value, field_frame.lat.value
+    obs_time = Time(map_field.date)
+    dsun_obs = header_field["DSUN_OBS"]
+    return {"lon": lon, "lat": lat, "dsun_obs": dsun_obs, "obs_time": str(obs_time.iso)}
+
+
+def make_gen_chromo(chromo_box: dict) -> dict:
+    gen_keys = [
+        "dr",
+        "bcube",
+        "start_idx",
+        "end_idx",
+        "av_field",
+        "phys_length",
+        "voxel_status",
+        "apex_idx",
+        "codes",
+        "seed_idx",
+    ]
+    gen = {k: chromo_box[k] for k in gen_keys if k in chromo_box}
+    if "attrs" in chromo_box:
+        gen["attrs"] = chromo_box["attrs"]
+    return gen
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run AMPP stages headlessly and save POT/NAS/GEN/CHR HDF5 files.")
+    parser.add_argument("--data-dir", required=True, help="Directory with HMI fits (*.field.fits, etc.).")
+    parser.add_argument("--gxmodel-dir", required=True, help="Output gx_models directory.")
+    parser.add_argument("--time", required=True, help="Observation time ISO (used for naming).")
+    parser.add_argument("--coords", nargs=2, type=float, required=True, metavar=("X", "Y"),
+                        help="Center coords: arcsec if --hpc, degrees if --hgc.")
+    parser.add_argument("--hpc", action="store_true", help="Interpret coords as helioprojective (arcsec).")
+    parser.add_argument("--hgc", action="store_true", help="Interpret coords as heliographic carrington (deg).")
+    parser.add_argument("--box-dims", nargs=3, type=int, required=True, metavar=("NX", "NY", "NZ"),
+                        help="Box dimensions in pixels.")
+    parser.add_argument("--box-res", type=float, required=True,
+                        help="Box resolution in Mm per pixel.")
+    parser.add_argument("--coord-tag", default=None,
+                        help="Override coordinate tag in filename, e.g., E73S3CR. If not set, derive from map header.")
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir).expanduser().resolve()
+    maps = load_hmi_maps(data_dir)
+
+    obs_time = Time(args.time)
+    out_dir = make_out_dir(args.gxmodel_dir, obs_time)
+
+    if args.hpc == args.hgc:
+        raise SystemExit("Specify exactly one of --hpc or --hgc.")
+
+    map_bp, map_bt, map_br = hmi_b2ptr(maps["field"], maps["inclination"], maps["azimuth"])
+
+    nx, ny, nz = args.box_dims
+    res = args.box_res * u.Mm
+    res_km = res.to(u.km).value
+
+    # Cutouts
+    if args.hpc:
+        center_crd = SkyCoord(args.coords[0] * u.arcsec, args.coords[1] * u.arcsec,
+                              frame=maps["field"].coordinate_frame)
+    else:
+        center_crd = SkyCoord(lon=args.coords[0] * u.deg, lat=args.coords[1] * u.deg,
+                              radius=maps["field"].center.heliographic_carrington.radius,
+                              obstime=maps["field"].date,
+                              observer="earth",
+                              frame="heliographic_carrington")
+
+    box_bx = cutout2box(map_bp, center_crd, res_km * u.km, [ny, nx])
+    box_by = cutout2box(map_bt, center_crd, res_km * u.km, [ny, nx])
+    box_bz = cutout2box(map_br, center_crd, res_km * u.km, [ny, nx])
+    box_by.data[:, :] *= -1.0
+
+    # Potential field
+    maglib_lff = MagFieldLinFFF()
+    maglib_lff.set_field(box_bz.data.T)
+    pot_res = maglib_lff.LFFF_cube(nz=nz)
+
+    pot_bx = pot_res["by"].swapaxes(0, 1)
+    pot_by = pot_res["bx"].swapaxes(0, 1)
+    pot_bz = pot_res["bz"].swapaxes(0, 1)
+    obs_dr = res.to(u.km) / sun_consts.radius.to(u.km)
+    dr3 = [obs_dr.value, obs_dr.value, obs_dr.value]
+    pot_box = {"corona": {"bx": pot_bx, "by": pot_by, "bz": pot_bz, "dr": np.array(dr3),
+                          "attrs": {"model_type": "pot"}}}
+
+    header = build_header(maps["field"])
+    coord_tag = args.coord_tag or build_coord_tag(header["lon"], header["lat"])
+
+    write_b3d_h5(str(stage_filename(out_dir, obs_time, coord_tag, "POT")), pot_box)
+
+    # NLFFF: replace bottom boundary in potential
+    bx_lff = pot_bx.copy()
+    by_lff = pot_by.copy()
+    bz_lff = pot_bz.copy()
+    bx_lff[:, :, 0] = box_bx.data
+    by_lff[:, :, 0] = box_by.data
+    bz_lff[:, :, 0] = box_bz.data
+
+    maglib = MagFieldProcessor()
+    maglib.load_cube_vars(pot_res)
+    res_nlf = maglib.NLFFF()
+
+    nlfff_bx = res_nlf["by"].swapaxes(0, 1)
+    nlfff_by = res_nlf["bx"].swapaxes(0, 1)
+    nlfff_bz = res_nlf["bz"].swapaxes(0, 1)
+    nlfff_box = {"corona": {"bx": nlfff_bx, "by": nlfff_by, "bz": nlfff_bz, "dr": np.array(dr3),
+                            "attrs": {"model_type": "nlfff"}}}
+    write_b3d_h5(str(stage_filename(out_dir, obs_time, coord_tag, "NAS")), nlfff_box)
+
+    # Field lines + chromosphere
+    lines = maglib.lines(seeds=None)
+
+    base_bz = cutout2box(maps["magnetogram"], center_crd, res_km * u.km, [ny, nx])
+    base_ic = cutout2box(maps["continuum"], center_crd, res_km * u.km, [ny, nx])
+
+    obs_dr = res.to(u.km) / sun_consts.radius.to(u.km)
+    dr3 = [obs_dr.value, obs_dr.value, obs_dr.value]
+
+    chromo_box = combo_model({"bx": nlfff_bx, "by": nlfff_by, "bz": nlfff_bz}, dr3, base_bz.data.T, base_ic.data.T)
+    for k in ["codes", "apex_idx", "start_idx", "end_idx", "seed_idx",
+              "av_field", "phys_length", "voxel_status"]:
+        chromo_box[k] = lines[k]
+    chromo_box["phys_length"] *= dr3[0]
+    chromo_box["attrs"] = header
+
+    gen_box = {"chromo": make_gen_chromo(chromo_box)}
+    write_b3d_h5(str(stage_filename(out_dir, obs_time, coord_tag, "NAS.GEN")), gen_box)
+
+    chr_box = {"chromo": chromo_box}
+    write_b3d_h5(str(stage_filename(out_dir, obs_time, coord_tag, "NAS.CHR")), chr_box)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyampp/util/compute.py
+++ b/pyampp/util/compute.py
@@ -41,7 +41,7 @@ def cutout2box(_map, center_x, center_y, dx_km, shape):
     box_header = sunpy.map.make_fitswcs_header(shape, origin,
                                                projection_code='CEA', scale=scale)
 
-    outmap = _map.reproject_to(box_header, algorithm="adaptive", roundtrip_coords=False)
+    outmap = _map.reproject_to(box_header, algorithm="exact")
     return outmap
 
 
@@ -87,7 +87,8 @@ def hmi_b2ptr(map_field, map_inclination, map_azimuth):
     bptr[1, :, :] = k21 * b_xi + k22 * b_eta + k23 * b_zeta
     bptr[2, :, :] = k11 * b_xi + k12 * b_eta + k13 * b_zeta
 
-    header = map_field.fits_header
+    # Preserve HMI RSUN in WCS metadata for downstream reprojection parity.
+    header = map_field.meta
     map_bp = sunpy.map.Map(bptr[0, :, :], header)
     map_bt = sunpy.map.Map(bptr[1, :, :], header)
     map_br = sunpy.map.Map(bptr[2, :, :], header)
@@ -220,4 +221,3 @@ def ampp_field(dl_path, out_model, x, y, dx, dy, dz, res):
     #     chromo_ds.create_dataset(k, data=chromo_box[k])
     # out_file.flush()
     out_file.close()
-

--- a/pyampp/util/config.py
+++ b/pyampp/util/config.py
@@ -27,7 +27,7 @@ def aia_euv_passbands():
 
 def aia_uv_passbands():
     """ Return the passbands for the SDO/AIA instrument. """
-    return ['1600']
+    return ['1600', '1700']
 
 def hmi_b_segments():
     """ Return the segments for the HMI magnetogram. """
@@ -35,7 +35,7 @@ def hmi_b_segments():
 
 def jsoc_notify_email():
     """ Return the email address for JSOC notifications. """
-    return "suncasa-group@njit.edu"
+    return os.environ.get("PYAMPP_JSOC_NOTIFY_EMAIL", "suncasa-group@njit.edu")
 
 def hmi_b_products():
     """ Return the products for the HMI magnetogram. """

--- a/pyampp/util/h5tree.py
+++ b/pyampp/util/h5tree.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+import h5py
+import typer
+
+app = typer.Typer(help="Print a tree view of an HDF5 file.")
+
+
+def _format_attrs(attrs: dict[str, Any], max_len: int | None) -> str:
+    if not attrs:
+        return ""
+    parts = []
+    for key, value in attrs.items():
+        text = f"{key}={value!r}"
+        if max_len is not None and len(text) > max_len:
+            text = text[: max_len - 3] + "..."
+        parts.append(text)
+    return " {" + ", ".join(parts) + "}"
+
+
+def _matches_filter(full_path: str, name: str, flt: Optional[str]) -> bool:
+    if not flt:
+        return True
+    flt = flt.lower()
+    return flt in full_path.lower() or flt in name.lower()
+
+
+def _print_group(
+    group: h5py.Group,
+    prefix: str,
+    show_attrs: bool,
+    max_attr_len: int | None,
+    max_depth: int | None,
+    current_depth: int,
+    flt: Optional[str],
+    base_path: str,
+) -> None:
+    if max_depth is not None and current_depth > max_depth:
+        return
+    keys = list(group.keys())
+    for idx, name in enumerate(keys):
+        is_last = idx == len(keys) - 1
+        branch = "└── " if is_last else "├── "
+        child = group[name]
+        full_path = f"{base_path}/{name}"
+        if isinstance(child, h5py.Dataset):
+            shape = child.shape
+            dtype = child.dtype
+            attrs = dict(child.attrs) if show_attrs else {}
+            attr_text = _format_attrs(attrs, max_attr_len)
+            if _matches_filter(full_path, name, flt):
+                print(f"{prefix}{branch}{name} {shape} {dtype}{attr_text}")
+        else:
+            attrs = dict(child.attrs) if show_attrs else {}
+            attr_text = _format_attrs(attrs, max_attr_len)
+            if _matches_filter(full_path, name, flt):
+                print(f"{prefix}{branch}{name}/{attr_text}")
+            extension = "    " if is_last else "│   "
+            _print_group(
+                child,
+                prefix + extension,
+                show_attrs,
+                max_attr_len,
+                max_depth,
+                current_depth + 1,
+                flt,
+                full_path,
+            )
+
+
+@app.command()
+def main(
+    ctx: typer.Context,
+    path: Optional[Path] = typer.Argument(None, exists=True, file_okay=True, dir_okay=False, readable=True),
+    show_attrs: bool = typer.Option(False, "--attrs", help="Show dataset/group attributes."),
+    max_attr_len: int | None = typer.Option(120, "--attr-max", help="Max length for each attribute entry."),
+    max_depth: int | None = typer.Option(None, "--max-depth", help="Limit recursion depth."),
+    flt: Optional[str] = typer.Option(None, "--filter", help="Only show paths matching this string."),
+    show_metadata: bool = typer.Option(False, "--show-metadata", help="Print metadata/id and metadata/execute if present."),
+) -> None:
+    """Print a tree of groups/datasets with shapes and dtypes."""
+    if path is None:
+        print(ctx.get_help())
+        raise typer.Exit(code=0)
+    with h5py.File(path, "r") as h5f:
+        print(f"{path}")
+        _print_group(h5f, "", show_attrs, max_attr_len, max_depth, 0, flt, "")
+        if show_metadata and "metadata" in h5f:
+            meta = h5f["metadata"]
+            for key in meta.keys():
+                val = meta[key][()]
+                if isinstance(val, (bytes, bytearray)):
+                    val = val.decode()
+                print(f"metadata/{key}: {val}")
+
+
+if __name__ == "__main__":
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,11 @@ dynamic = ["version"]
 [project.scripts]
 pyampp = "pyampp.gxbox.gxampp:app"
 gxbox = "pyampp.gxbox.gxbox_factory:app"
+gxbox-view = "pyampp.gxbox.view_h5:main"
+gx-fov2box = "pyampp.gxbox.gx_fov2box:app"
+gx_fov2box = "pyampp.gxbox.gx_fov2box:app"
+h5tree = "pyampp.util.h5tree:app"
+gxrefmap-view = "pyampp.gxbox.gxrefmap_view:app"
 
 [project.optional-dependencies]
 tests = [


### PR DESCRIPTION
## Summary

This PR upgrades pyAMPP’s saved GX model formats and supporting tools to improve IDL/Python interoperability, traceability, and downstream rendering compatibility.

## What Changed

### 1) HDF5 stage format upgrades (`gx-fov2box`)
- Standardized stage outputs across:
  - `NONE`, `BND`, `POT`, `NAS`, `NAS.GEN`, `NAS.CHR`
- Added/normalized key groups and payloads:
  - `base/*` (including canonical `base/index`)
  - `metadata/*` (including full command provenance in `metadata/execute`)
  - `grid/*` (including `voxel_id`, `dx`, `dy`, `dz`)
  - `refmaps/<map_id>/{data,wcs_header}`
  - stage-specific `corona` / `bounds` / `chromo` products

### 2) Voxel-ID and parity helpers
- Added reusable voxel-id utilities and wiring needed for CHR compatibility.
- Added conversion/comparison utilities under tests to check HDF5 vs IDL model consistency.
- Improved support for parity workflows used by `gximagecomputing`.

### 3) Viewer and CLI support updates
- Updated viewers/tools to work with upgraded structures:
  - `gxbox-view`
  - `gxrefmap-view`
  - related HDF5 browsing/loading paths
- Added/updated utilities for HDF5 tree inspection and model introspection.

### 4) Documentation improvements
- Added canonical model format documentation:
  - `docs/model_hdf5_format.rst`
- Added viewer documentation:
  - `docs/viewers.rst`
- Linked new docs from:
  - `docs/index.rst`
  - `README.rst`

## Why

- Ensure stable, explicit data contracts for downstream science workflows.
- Improve compatibility with GX Simulator/IDL data expectations.
- Make model files self-describing and easier to inspect/validate.
- Reduce ambiguity for users generating and viewing model stages.

## Validation

- Exercised upgraded `gx-fov2box` stage generation workflow.
- Verified produced HDF5 structure with tree/metadata inspection.
- Ran parity-oriented test scripts used for IDL/HDF5 comparisons.
- Confirmed updated viewers can read upgraded model layout.

## Notes

- This PR focuses on pyAMPP only.
- Generated local artifacts (plots/reports) are excluded from commit history.
