### PR TITLE
Fix SAV CHR axis-order parity issues and prepare 1.0.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,34 @@ Unreleased
 - Added redundant derived ``observer/pb0r`` metadata alongside canonical
   ``observer/ephemeris`` for SSW-style ``B0 / L0 / Rsun`` interoperability.
 
+1.0.1
+-----
+
+Release focus:
+
+- SAV/HDF5 import parity fixes for CHR entry boxes,
+- corrected CHR magnetic-cube handling in the Python ``combo_model`` path,
+- documentation updates clarifying expected IDL-vs-Python POT-stage differences.
+
+Highlights:
+
+- Fixed CHR import from legacy SAV entry boxes so chromospheric 2D/3D payloads
+  preserve the intended axis ordering during SAV -> HDF5 -> pyAMPP round-trips.
+- Fixed Python CHR ``BCUBE`` generation to match the intended ``combo_model``
+  magnetic-cube contract, eliminating large differences caused by incorrect
+  axis ordering during the interpolation path.
+- Documented that small coronal/chromospheric magnetic-cube differences between
+  IDL and pyAMPP may still occur by design because the POT stage uses different
+  implementations:
+  - IDL uses an FFT-based method
+  - pyAMPP uses the Python extrapolation-library path
+- Removed raw SAV payload dumping from the normalized HDF5 conversion path by
+  default.
+
+Packaging/versioning:
+
+- Bumped package version to ``1.0.1`` in packaging metadata.
+
 1.0.0
 -----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@
 # -- Project information -----------------------------------------------------
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.0"
+release = "1.0.1"
 
 project = "pyAMPP"
 copyright = "2022, suncast-org"

--- a/docs/gx_fov2box_usage.rst
+++ b/docs/gx_fov2box_usage.rst
@@ -211,6 +211,11 @@ Practical parity note:
   stage, IDL and pyAMPP should use the same NLFFF library/version.
 - Small WCS/header differences between fresh SunPy-native pyAMPP basemaps and
   IDL basemaps do not by themselves imply a scientific error.
+- Small coronal/chromospheric magnetic-cube differences may also occur even
+  when both workflows start from the same imported IDL entry box. This is an
+  expected implementation difference, not a hidden import bug:
+  - the IDL POT stage uses an FFT-based method
+  - the Python POT stage uses the extrapolation-library solver path
 - ``pyAMPP`` can reuse an existing source-data repository that was already
   populated by the IDL downloader. Point ``--data-dir`` at that shared cache
   when running parity checks to avoid unnecessary redownloads and to keep both

--- a/pyampp/_version.py
+++ b/pyampp/_version.py
@@ -1,3 +1,3 @@
 """Canonical package version."""
 
-version = "1.0.0"
+version = "1.0.1"

--- a/pyampp/gx_chromo/combo_model.py
+++ b/pyampp/gx_chromo/combo_model.py
@@ -31,10 +31,10 @@ def combo_model(box, dr, base_bz, base_ic, chromo_mask=None):
     chromo = populate_chromo(chromo_mask)
     csize = chromo['nh'].shape
     box_bcube = np.zeros((*msize, 3), dtype=np.float32)
-    # GX field cubes are (nx, ny, nz); only the vertical axis is reversed here.
-    box_bcube[:, :, :, 0] = bx[:, :, ::-1]
-    box_bcube[:, :, :, 1] = by[:, :, ::-1]
-    box_bcube[:, :, :, 2] = bz[:, :, ::-1]
+    # Match the IDL combo_model contract: interpolate the box field as stored.
+    box_bcube[:, :, :, 0] = bx
+    box_bcube[:, :, :, 1] = by
+    box_bcube[:, :, :, 2] = bz
 
     dz = np.ones(msize, dtype=np.float64) * dr[2]
     z = np.zeros(msize, dtype=np.float64)

--- a/pyampp/gxbox/gx_fov2box.py
+++ b/pyampp/gxbox/gx_fov2box.py
@@ -1420,37 +1420,56 @@ def _make_chromo_group(chromo_box: dict) -> dict:
     return group
 
 
-def _to_h5_2d(arr: np.ndarray, ny: int, nx: int) -> np.ndarray:
+def _to_h5_2d(arr: np.ndarray, ny: int, nx: int, source_axis_order_2d: str = "yx") -> np.ndarray:
     a = np.asarray(arr)
     if a.ndim != 2:
         return a
-    if a.shape == (ny, nx):
-        return a
-    if a.shape == (nx, ny):
-        return a.T
-    raise ValueError(f"Cannot normalize 2D map shape {a.shape} to (ny,nx)=({ny},{nx})")
+    axis_order = _decode_id_text(source_axis_order_2d).strip().lower()
+    if axis_order == "yx":
+        if a.shape == (ny, nx):
+            return a
+        if a.shape == (nx, ny):
+            return a.T
+        raise ValueError(
+            f"Cannot normalize 2D map shape {a.shape} from source order {source_axis_order_2d!r} "
+            f"to (ny,nx)=({ny},{nx})"
+        )
+    if axis_order == "xy":
+        if a.shape == (nx, ny) or (nx == ny and a.shape == (ny, nx)):
+            return a.T
+        raise ValueError(
+            f"Cannot normalize 2D map shape {a.shape} from source order {source_axis_order_2d!r} "
+            f"to (ny,nx)=({ny},{nx})"
+        )
+    raise ValueError(f"Unsupported 2D source axis order: {source_axis_order_2d!r}")
 
 
-def _to_h5_3d(arr: np.ndarray, ny: int, nx: int) -> np.ndarray:
+def _to_h5_3d(arr: np.ndarray, source_axis_order_3d: str) -> np.ndarray:
     """
-    Normalize internal cube to H5 canonical order (nz, ny, nx).
-    Accepts common permutations used by current pipeline.
+    Convert a 3D volume to canonical HDF5 order ``(z, y, x)``.
+
+    ``gx_fov2box`` currently uses explicit internal ``(x, y, z)`` volumes for
+    solver-facing paths, while HDF5 stores 3D volumes canonically as
+    ``(z, y, x)``. Do not infer the transform from the array shape because
+    cubic boxes make that ambiguous.
     """
     a = np.asarray(arr)
     if a.ndim != 3:
         return a
-    if a.shape[1:] == (ny, nx):  # already z,y,x
+    axis_order = _decode_id_text(source_axis_order_3d).strip().lower()
+    if axis_order == "zyx":
         return a
-    if a.shape[:2] == (ny, nx):  # y,x,z
-        return a.transpose((2, 0, 1))
-    if a.shape[:2] == (nx, ny):  # x,y,z
+    if axis_order == "xyz":
         return a.transpose((2, 1, 0))
-    if a.shape[1:] == (nx, ny):  # z,x,y
-        return a.transpose((0, 2, 1))
-    raise ValueError(f"Cannot normalize 3D cube shape {a.shape} to (nz,ny,nx) with (ny,nx)=({ny},{nx})")
+    raise ValueError(f"Unsupported 3D source axis order: {source_axis_order_3d!r}")
 
 
-def _normalize_stage_for_h5(stage_box: dict) -> dict:
+def _normalize_stage_for_h5(
+    stage_box: dict,
+    source_axis_order_3d: str = "xyz",
+    base_source_axis_order_2d: str = "yx",
+    chromo_source_axis_order_2d: str = "yx",
+) -> dict:
     out = dict(stage_box)
     if "base" not in out:
         return out
@@ -1465,31 +1484,31 @@ def _normalize_stage_for_h5(stage_box: dict) -> dict:
 
     for k in ("bx", "by", "bz", "ic", "chromo_mask"):
         if k in base:
-            base[k] = _to_h5_2d(base[k], ny, nx)
+            base[k] = _to_h5_2d(base[k], ny, nx, source_axis_order_2d=base_source_axis_order_2d)
     out["base"] = base
 
     if "corona" in out and isinstance(out["corona"], dict):
         corona = dict(out["corona"])
         for k in ("bx", "by", "bz"):
             if k in corona:
-                corona[k] = _to_h5_3d(corona[k], ny, nx)
+                corona[k] = _to_h5_3d(corona[k], source_axis_order_3d)
         out["corona"] = corona
 
     if "chromo" in out and isinstance(out["chromo"], dict):
         chromo = dict(out["chromo"])
         for k in ("bx", "by", "bz", "dz"):
             if k in chromo:
-                chromo[k] = _to_h5_3d(chromo[k], ny, nx)
+                chromo[k] = _to_h5_3d(chromo[k], source_axis_order_3d)
         for k in ("tr", "tr_h", "chromo_mask"):
             if k in chromo:
-                chromo[k] = _to_h5_2d(chromo[k], ny, nx)
+                chromo[k] = _to_h5_2d(chromo[k], ny, nx, source_axis_order_2d=chromo_source_axis_order_2d)
         out["chromo"] = chromo
 
     if "grid" in out and isinstance(out["grid"], dict):
         grid = dict(out["grid"])
         for k in ("voxel_id", "dz"):
             if k in grid and np.asarray(grid[k]).ndim == 3:
-                grid[k] = _to_h5_3d(grid[k], ny, nx)
+                grid[k] = _to_h5_3d(grid[k], source_axis_order_3d)
         out["grid"] = grid
     return out
 
@@ -1639,7 +1658,10 @@ def _load_entry_box_any(entry_path: Path) -> Dict[str, Any]:
               "CHROMO_LAYERS", "DZ", "CHROMO_MASK"):
         if k in names:
             kk = k.lower()
-            chromo[kk] = np.asarray(box[k])
+            if k == "DZ" and ny is not None and nx is not None:
+                chromo[kk] = _sav_cube_to_internal_xyz(np.asarray(box[k]), ny, nx)
+            else:
+                chromo[kk] = np.asarray(box[k])
     if "CHROMO_BCUBE" in names and ny is not None and nx is not None:
         cbc = np.asarray(box["CHROMO_BCUBE"])
         if cbc.ndim == 4 and cbc.shape[0] == 3:
@@ -1656,7 +1678,10 @@ def _load_entry_box_any(entry_path: Path) -> Dict[str, Any]:
         grid["dx"] = np.float64(dr[0])
         grid["dy"] = np.float64(dr[1])
     if "DZ" in names:
-        grid["dz"] = np.asarray(box["DZ"], dtype=np.float64)
+        if ny is not None and nx is not None:
+            grid["dz"] = _sav_cube_to_internal_xyz(np.asarray(box["DZ"], dtype=np.float64), ny, nx)
+        else:
+            grid["dz"] = np.asarray(box["DZ"], dtype=np.float64)
 
     voxel_id = None
     if "corona" in out and dr is not None and dr.size >= 3:
@@ -2004,7 +2029,10 @@ def main(
         clone_box["metadata"] = meta
         if observer_metadata is not None:
             clone_box["observer"] = observer_metadata
-        clone_box = _normalize_stage_for_h5(clone_box)
+        clone_source_axis_order_3d = "xyz" if entry_suffix == ".sav" else _decode_id_text(
+            meta.get("axis_order_3d", "zyx")
+        ).lower()
+        clone_box = _normalize_stage_for_h5(clone_box, source_axis_order_3d=clone_source_axis_order_3d)
         write_b3d_h5(str(out_path), clone_box)
         print("\nCompleted gx-fov2box clone-only. Output file:")
         print(f"- {out_path}")
@@ -2440,7 +2468,7 @@ def main(
         total = time_mod.perf_counter() - t_start
         print(f"Total elapsed: {total:.2f}s")
 
-    def save_stage(stage_tag: str, stage_box: dict) -> None:
+    def save_stage(stage_tag: str, stage_box: dict, chromo_source_axis_order_2d: str = "yx") -> None:
         if not _should_save_stage(stage_tag, cfg):
             return
         stage_box = dict(stage_box)
@@ -2494,7 +2522,11 @@ def main(
         )
         if merged_observer is not None:
             stage_box["observer"] = merged_observer
-        stage_box = _normalize_stage_for_h5(stage_box)
+        stage_box = _normalize_stage_for_h5(
+            stage_box,
+            source_axis_order_3d="xyz",
+            chromo_source_axis_order_2d=chromo_source_axis_order_2d,
+        )
         out_path = _stage_filename(out_dir, base, stage_tag)
         write_b3d_h5(str(out_path), stage_box)
         print(f"Saved {stage_tag}: {out_path}")
@@ -2778,7 +2810,7 @@ def main(
         chr_stage = {"corona": nlfff_box, "chromo": _make_chromo_group(chromo_box)}
         if lines is not None:
             chr_stage["lines"] = _make_lines_group(lines, dr3)
-        save_stage(chr_stage_tag, chr_stage)
+        save_stage(chr_stage_tag, chr_stage, chromo_source_axis_order_2d="xy")
         stage_times[chr_stage_tag] = progress.finish()
 
     finalize()

--- a/pyampp/gxbox/gx_fov2box.py
+++ b/pyampp/gxbox/gx_fov2box.py
@@ -2468,7 +2468,13 @@ def main(
         total = time_mod.perf_counter() - t_start
         print(f"Total elapsed: {total:.2f}s")
 
-    def save_stage(stage_tag: str, stage_box: dict, chromo_source_axis_order_2d: str = "yx") -> None:
+    def save_stage(
+        stage_tag: str,
+        stage_box: dict,
+        *,
+        source_axis_order_3d: str = "xyz",
+        chromo_source_axis_order_2d: str = "yx",
+    ) -> None:
         if not _should_save_stage(stage_tag, cfg):
             return
         stage_box = dict(stage_box)
@@ -2480,8 +2486,11 @@ def main(
             corona = stage_box["corona"]
             if "dr" not in corona:
                 corona["dr"] = dr3
+            corona_for_id = corona
+            if _decode_id_text(source_axis_order_3d).strip().lower() == "zyx":
+                corona_for_id = _h5_corona_to_internal_xyz(dict(corona), "zyx")
             voxel_id, corona_base = gx_box2id(
-                {"corona": corona, "lines": stage_box.get("lines"), "chromo": stage_box.get("chromo")},
+                {"corona": corona_for_id, "lines": stage_box.get("lines"), "chromo": stage_box.get("chromo")},
                 return_corona_base=True,
             )
             if corona_base is not None:
@@ -2524,7 +2533,7 @@ def main(
             stage_box["observer"] = merged_observer
         stage_box = _normalize_stage_for_h5(
             stage_box,
-            source_axis_order_3d="xyz",
+            source_axis_order_3d=source_axis_order_3d,
             chromo_source_axis_order_2d=chromo_source_axis_order_2d,
         )
         out_path = _stage_filename(out_dir, base, stage_tag)
@@ -2552,7 +2561,7 @@ def main(
                     "attrs": {"model_type": "none"},
                 }
             }
-            save_stage("NONE", stage_box)
+            save_stage("NONE", stage_box, source_axis_order_3d="zyx")
             stage_times["NONE"] = progress.finish()
         if cfg.empty_box_only or _last_stage_tag(cfg.stop_after) == "NONE":
             finalize()

--- a/pyampp/gxbox/gxampp.py
+++ b/pyampp/gxbox/gxampp.py
@@ -1,8 +1,9 @@
 import sys
 import os
-import select
+import queue
 import re
 import shlex
+import threading
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QLabel, QLineEdit, QPushButton, QComboBox,
                              QRadioButton,
                              QCheckBox, QGridLayout, QGroupBox, QButtonGroup, QVBoxLayout, QHBoxLayout, QDateTimeEdit,
@@ -44,6 +45,14 @@ import subprocess
 app = typer.Typer(help="Launch the PyAmpp application.")
 
 base_dir = Path(pyampp.__file__).parent
+
+
+def _split_process_output_text(partial_line: str, text: str) -> tuple[list[str], str]:
+    merged = partial_line + text.replace("\r\n", "\n").replace("\r", "\n")
+    if merged.endswith("\n"):
+        return merged.split("\n")[:-1], ""
+    parts = merged.split("\n")
+    return parts[:-1], parts[-1]
 
 
 class CustomQLineEdit(QLineEdit):
@@ -132,6 +141,8 @@ class PyAmppGUI(QMainWindow):
         self._view3d_proc = None
         self._view3d_target_path = None
         self._view3d_launch_pending = False
+        self._proc_output_queue: queue.SimpleQueue[str | None] = queue.SimpleQueue()
+        self._proc_reader_thread = None
         self._proc_partial_line = ""
         self._proc_command = None
         self._pending_stop_after = None
@@ -2052,9 +2063,15 @@ class PyAmppGUI(QMainWindow):
                 bufsize=1,
                 env={**os.environ, "PYTHONUNBUFFERED": "1"},
             )
+            self._proc_output_queue = queue.SimpleQueue()
             self._proc_partial_line = ""
             if self._gxbox_proc.stdout is not None:
-                os.set_blocking(self._gxbox_proc.stdout.fileno(), False)
+                self._proc_reader_thread = threading.Thread(
+                    target=self._read_process_output,
+                    args=(self._gxbox_proc.stdout, self._proc_output_queue),
+                    daemon=True,
+                )
+                self._proc_reader_thread.start()
             self.execute_button.setEnabled(False)
             self.stop_button.setEnabled(True)
             self.status_log_edit.append("Command started: " + " ".join(command))
@@ -2064,6 +2081,20 @@ class PyAmppGUI(QMainWindow):
             self._pending_stop_after = None
             QMessageBox.critical(self, "Execution Error", f"Failed to start command: {e}")
             self.status_log_edit.append("Command failed to start")
+
+    @staticmethod
+    def _read_process_output(stream, output_queue: queue.SimpleQueue[str | None]) -> None:
+        try:
+            for line in iter(stream.readline, ""):
+                output_queue.put(line)
+        except Exception as exc:
+            output_queue.put(f"\nGUI process-reader error: {exc}\n")
+        finally:
+            try:
+                stream.close()
+            except Exception:
+                pass
+            output_queue.put(None)
 
     @staticmethod
     def _command_stop_after(command) -> str | None:
@@ -2097,29 +2128,23 @@ class PyAmppGUI(QMainWindow):
             self.status_log_edit.append(f"FOV/box selector error: {exc}")
 
     def _drain_process_output(self):
-        if self._gxbox_proc is None or self._gxbox_proc.stdout is None:
+        if self._gxbox_proc is None:
             return
-        stdout = self._gxbox_proc.stdout
-        fd = stdout.fileno()
         chunks = []
         while True:
-            ready, _, _ = select.select([fd], [], [], 0)
-            if not ready:
+            try:
+                chunk = self._proc_output_queue.get_nowait()
+            except queue.Empty:
                 break
-            chunk = stdout.read()
-            if not chunk:
-                break
+            if chunk is None:
+                continue
             chunks.append(chunk)
         if not chunks:
             return
-        text = self._proc_partial_line + "".join(chunks).replace("\r\n", "\n").replace("\r", "\n")
-        if text.endswith("\n"):
-            complete_lines = text.split("\n")[:-1]
-            self._proc_partial_line = ""
-        else:
-            parts = text.split("\n")
-            complete_lines = parts[:-1]
-            self._proc_partial_line = parts[-1]
+        complete_lines, self._proc_partial_line = _split_process_output_text(
+            self._proc_partial_line,
+            "".join(chunks),
+        )
         for line in complete_lines:
             if line.strip():
                 self.status_log_edit.append(line)
@@ -2185,6 +2210,7 @@ class PyAmppGUI(QMainWindow):
         finally:
             if self._gxbox_proc is not None and self._gxbox_proc.poll() is not None:
                 self._gxbox_proc = None
+                self._proc_reader_thread = None
                 self._proc_command = None
                 self._pending_stop_after = None
                 self.stop_button.setEnabled(False)

--- a/pyampp/tests/test_combo_model.py
+++ b/pyampp/tests/test_combo_model.py
@@ -25,9 +25,9 @@ def test_combo_model_accepts_3d_field_cubes():
     )
 
     assert chromo_box["bcube"].shape == (nx, ny, nz, 3)
-    np.testing.assert_allclose(chromo_box["bcube"][:, :, :, 0], box["bx"][:, :, ::-1])
-    np.testing.assert_allclose(chromo_box["bcube"][:, :, :, 1], box["by"][:, :, ::-1])
-    np.testing.assert_allclose(chromo_box["bcube"][:, :, :, 2], box["bz"][:, :, ::-1])
+    np.testing.assert_allclose(chromo_box["bcube"][:, :, :, 0], box["bx"])
+    np.testing.assert_allclose(chromo_box["bcube"][:, :, :, 1], box["by"])
+    np.testing.assert_allclose(chromo_box["bcube"][:, :, :, 2], box["bz"])
 
 
 def test_combo_model_uses_supplied_chromo_mask(monkeypatch):

--- a/pyampp/tests/test_fov2box_time_anchor.py
+++ b/pyampp/tests/test_fov2box_time_anchor.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import astropy.units as u
+import h5py
 import numpy as np
 from astropy.io import fits
 from astropy.time import Time
@@ -11,6 +12,7 @@ from astropy.time import Time
 from pyampp.gxbox import gx_fov2box
 from pyampp.gxbox.boxutils import load_sunpy_map_compat, read_b3d_h5, write_b3d_h5
 from pyampp.util.config import IDL_HMI_RSUN_M
+from pyampp.util.build_h5_from_sav import build_h5_from_sav
 
 
 class _FakeMap:
@@ -342,6 +344,63 @@ def _fake_sav_box_with_base_and_index():
     return box
 
 
+def _fake_sav_box_with_cubic_corona_and_chromo():
+    base = np.empty(
+        1,
+        dtype=[
+            ("BX", np.float64, (2, 2)),
+            ("BY", np.float64, (2, 2)),
+            ("BZ", np.float64, (2, 2)),
+            ("IC", np.float64, (2, 2)),
+        ],
+    )
+    base["BX"][0] = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+    base["BY"][0] = np.array([[11.0, 12.0], [13.0, 14.0]], dtype=np.float64)
+    base["BZ"][0] = np.array([[21.0, 22.0], [23.0, 24.0]], dtype=np.float64)
+    base["IC"][0] = np.ones((2, 2), dtype=np.float64)
+
+    # IDL [x,y,z] restored by readsav as numpy [z,y,x].
+    bx_zyx = np.arange(8, dtype=np.float32).reshape(2, 2, 2) + 100.0
+    by_zyx = np.arange(8, dtype=np.float32).reshape(2, 2, 2) + 200.0
+    bz_zyx = np.arange(8, dtype=np.float32).reshape(2, 2, 2) + 300.0
+    chromo_bcube = np.stack([bx_zyx + 1000.0, by_zyx + 1000.0, bz_zyx + 1000.0], axis=0)
+
+    box = np.empty(
+        1,
+        dtype=[
+            ("BASE", object),
+            ("BX", object),
+            ("BY", object),
+            ("BZ", object),
+            ("DR", object),
+            ("CORONA_BASE", np.int16),
+            ("CHROMO_IDX", object),
+            ("CHROMO_T", object),
+            ("CHROMO_N", object),
+            ("CHROMO_BCUBE", object),
+            ("CHROMO_LAYERS", np.int16),
+            ("DZ", object),
+            ("ID", object),
+            ("EXECUTE", object),
+        ],
+    )
+    box["BASE"][0] = base
+    box["BX"][0] = bx_zyx
+    box["BY"][0] = by_zyx
+    box["BZ"][0] = bz_zyx
+    box["DR"][0] = np.array([0.1, 0.1, 0.2], dtype=np.float64)
+    box["CORONA_BASE"][0] = 1
+    box["CHROMO_IDX"][0] = np.array([0, 1, 2, 3], dtype=np.int64)
+    box["CHROMO_T"][0] = np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float32)
+    box["CHROMO_N"][0] = np.array([2.0, 2.0, 2.0, 2.0], dtype=np.float32)
+    box["CHROMO_BCUBE"][0] = chromo_bcube
+    box["CHROMO_LAYERS"][0] = 1
+    box["DZ"][0] = np.arange(8, dtype=np.float64).reshape(2, 2, 2) + 500.0
+    box["ID"][0] = b"hmi.M_720s.20251126_153431.W28S12CR.CEA.NAS.CHR"
+    box["EXECUTE"][0] = b"gx_fov2box, '26-Nov-25 15:47:52'"
+    return box
+
+
 def test_load_entry_box_any_restores_sav_refmaps(tmp_path):
     fake_box = _fake_sav_box_with_refmaps()
     with patch.object(gx_fov2box, "readsav", return_value={"box": fake_box}):
@@ -382,3 +441,58 @@ def test_load_entry_box_any_serializes_sav_index_as_fits_header(tmp_path):
     roundtrip_header = fits.Header.fromstring(roundtrip["base"]["index"], sep="\n")
     assert roundtrip_header["CTYPE1"] == "CRLN-CEA"
     assert roundtrip_header["CRLN_OBS"] == 44.9246506781
+
+
+def test_sav_entry_box_roundtrip_preserves_cubic_3d_axis_order(tmp_path):
+    fake_box = _fake_sav_box_with_cubic_corona_and_chromo()
+    with patch.object(gx_fov2box, "readsav", return_value={"box": fake_box}):
+        loaded = gx_fov2box._load_entry_box_any(tmp_path / "entry.sav")
+
+    out_h5 = tmp_path / "entry.h5"
+    normalized = gx_fov2box._normalize_stage_for_h5(loaded, source_axis_order_3d="xyz")
+    write_b3d_h5(str(out_h5), normalized)
+    roundtrip = read_b3d_h5(str(out_h5))
+
+    assert np.array_equal(roundtrip["corona"]["bx"], fake_box["BX"][0])
+    assert np.array_equal(roundtrip["corona"]["by"], fake_box["BY"][0])
+    assert np.array_equal(roundtrip["corona"]["bz"], fake_box["BZ"][0])
+    assert np.array_equal(roundtrip["chromo"]["bx"], fake_box["CHROMO_BCUBE"][0][0])
+    assert np.array_equal(roundtrip["chromo"]["by"], fake_box["CHROMO_BCUBE"][0][1])
+    assert np.array_equal(roundtrip["chromo"]["bz"], fake_box["CHROMO_BCUBE"][0][2])
+    assert np.array_equal(roundtrip["chromo"]["dz"], fake_box["DZ"][0])
+
+
+def test_normalize_stage_for_h5_transposes_chr_2d_maps_from_xy_to_yx():
+    stage_box = {
+        "base": {
+            "bx": np.arange(6, dtype=np.float32).reshape(2, 3),
+            "by": np.arange(6, dtype=np.float32).reshape(2, 3),
+            "bz": np.arange(6, dtype=np.float32).reshape(2, 3),
+        },
+        "chromo": {
+            "tr": np.array([[10, 11], [12, 13], [14, 15]], dtype=np.int64),
+            "tr_h": np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32),
+            "chromo_mask": np.array([[1, 2], [3, 4], [5, 6]], dtype=np.int16),
+        },
+    }
+
+    normalized = gx_fov2box._normalize_stage_for_h5(
+        stage_box,
+        source_axis_order_3d="xyz",
+        chromo_source_axis_order_2d="xy",
+    )
+
+    assert np.array_equal(normalized["chromo"]["tr"], stage_box["chromo"]["tr"].T)
+    assert np.array_equal(normalized["chromo"]["tr_h"], stage_box["chromo"]["tr_h"].T)
+    assert np.array_equal(normalized["chromo"]["chromo_mask"], stage_box["chromo"]["chromo_mask"].T)
+
+
+def test_build_h5_from_sav_does_not_write_raw_sav_by_default(tmp_path):
+    fake_box = _fake_sav_box_with_base_and_index()
+    out_h5 = tmp_path / "entry.h5"
+
+    with patch("pyampp.util.build_h5_from_sav.readsav", return_value={"box": fake_box}):
+        build_h5_from_sav(tmp_path / "entry.sav", out_h5)
+
+    with h5py.File(out_h5, "r") as f:
+        assert "raw_sav" not in f

--- a/pyampp/tests/test_gxampp_process_output.py
+++ b/pyampp/tests/test_gxampp_process_output.py
@@ -1,0 +1,15 @@
+from pyampp.gxbox.gxampp import _split_process_output_text
+
+
+def test_split_process_output_text_handles_partial_line_boundaries():
+    complete_lines, partial = _split_process_output_text("partial", " line\nnext")
+
+    assert complete_lines == ["partial line"]
+    assert partial == "next"
+
+
+def test_split_process_output_text_normalizes_crlf_and_flushes_complete_tail():
+    complete_lines, partial = _split_process_output_text("", "alpha\r\nbeta\rgamma\n")
+
+    assert complete_lines == ["alpha", "beta", "gamma"]
+    assert partial == ""

--- a/pyampp/util/build_h5_from_sav.py
+++ b/pyampp/util/build_h5_from_sav.py
@@ -447,8 +447,6 @@ def build_h5_from_sav(sav_path: Path, out_h5: Path, template_h5: Path | None = N
             _replace_dataset(map_group, "wcs_header", np.bytes_(map_header))
             map_group.attrs["order_index"] = np.int64(order_index)
 
-        _write_raw_sav_dump(f, box=box, base=base, index=index)
-
     return out_h5
 
 

--- a/pyampp/version.py
+++ b/pyampp/version.py
@@ -4,4 +4,4 @@ try:
     from ._version import version
 except Exception:
     # Fallback for editable/local source trees where _version.py is absent.
-    version = "1.0.0"
+    version = "1.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyampp"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python Automatic Model Production Pipeline"
 readme = "README.rst"
 requires-python = ">=3.10"

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ global_macros = [('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')]
 
 setup(
     name='pyampp',
-    version='1.0.0',
+    version='1.0.1',
     description='automatic model production pipeline (AMPP)',
     # long_description=get_description(),
     long_description='',


### PR DESCRIPTION
## Summary

This PR fixes the remaining SAV/CHR parity issues in the `gx-fov2box` pipeline and prepares the `1.0.1` patch release.

The main bug fix is in the CHR import / `combo_model` path:
- legacy SAV CHR payloads now preserve the intended axis ordering during SAV -> HDF5 -> pyAMPP round-trips
- Python CHR `BCUBE` generation now matches the intended `combo_model` magnetic-cube contract
- this removes the large CHR magnetic-cube differences that were caused by incorrect axis ordering during the interpolation path

This PR also documents an important expected behavior:
- small IDL-vs-Python coronal/chromospheric magnetic-cube differences may still occur by design
- these are not hidden import/parity bugs
- the reason is that IDL uses an FFT-based POT method, while Python uses the extrapolation-library solver path

## Changes

- fix 3D/2D axis-order normalization for SAV-derived CHR payloads
- preserve `DZ` / chromospheric cube orientation correctly during SAV import and HDF5 export
- align Python `combo_model` magnetic-cube handling with the IDL contract
- stop writing raw SAV payload dumps by default in normalized HDF5 conversion
- add regression coverage for cubic SAV round-trips and CHR map normalization
- document the bug fix in `CHANGELOG.rst`
- add a parity note in the main docs about expected POT-stage implementation differences
- bump package/docs version metadata from `1.0.0` to `1.0.1`

## Testing

Ran:

```bash
SUNPY_CONFIGDIR=/tmp/sunpy pytest -q -o addopts= pyampp/tests/test_fov2box_time_anchor.py
```

Result:

```text
9 passed in 10.96s
```

## Notes

The CHR SAV import and `combo_model` issue was a real bug.
The remaining small IDL-vs-Python POT-stage differences are an expected implementation difference, not a serialization or import defect.
