### PR TITLE
Promote gxbox geometry into public pyAMPP geometry API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,8 @@ Format and viewer references:
 
 - Upgraded HDF5 stage format (NONE/BND/POT/NAS/NAS.GEN/NAS.CHR):
   ``docs/model_hdf5_format.rst``
+- Public geometry API and migration status:
+  ``docs/geometry_api.rst``
 - Practical ``gx-fov2box`` CLI guide:
   ``docs/gx_fov2box_usage.rst``
 - Main GUI workflow and command mapping:

--- a/docs/geometry_api.rst
+++ b/docs/geometry_api.rst
@@ -71,7 +71,7 @@ Function Contracts
 
 - Input: an ``(N, 3)`` array of local Cartesian points in Mm
 - Output: a vectorized ``SkyCoord`` in the supplied world frame
-- Returns ``None`` when inputs are missing or invalid
+- Returns ``None`` when inputs are missing, invalid, or contain non-finite rows
 
 ``project_world_to_observer_hpc(world, observer=None, obstime=None, frame_obs=None)``
 

--- a/docs/geometry_api.rst
+++ b/docs/geometry_api.rst
@@ -1,0 +1,166 @@
+Public Geometry API
+===================
+
+The ``pyampp.geometry`` package is the public, headless geometry surface for
+observer-aware projection and field-of-view calculations. It promotes the
+tested gxbox geometry kernel into an import path that downstream code can rely
+on without depending on the GUI or viewer entrypoints.
+
+Scope of This Update
+--------------------
+
+This update cycle establishes the public Python geometry contract in pyAMPP.
+The immediate goals are:
+
+- expose the stable import surface through ``pyampp.geometry``
+- preserve existing gxbox behavior by routing current methods through wrappers
+- keep all transforms vectorized for arbitrary point sets and box corners
+- defer downstream adoption in gximagecomputing until this API is reviewed and merged upstream
+
+Public Import Surface
+---------------------
+
+Downstream consumers should import from ``pyampp.geometry`` rather than from
+``pyampp.gxbox`` internals.
+
+Current public exports include:
+
+- ``local_cartesian_to_world``
+- ``project_world_to_observer_hpc``
+- ``project_world_to_observer_hcc``
+- ``compute_inscribing_fov_from_hpc``
+- ``compute_inscribing_fov_from_world``
+- ``compute_inscribing_fov_box_from_world``
+- ``observer_fov_box_to_world_corners``
+- ``observer_rectangle_to_hpc_corners``
+- ``project_coordinate_edges_to_observer_hpc``
+- ``project_box_front_face_to_observer_hpc``
+- ``project_world_to_pixel``
+- observer-resolution helpers re-exported from ``pyampp.geometry.observer``
+
+Compatibility wrappers are still exposed through ``Box`` and
+``BoxGeometryMixin``, but these names are transitional compatibility surfaces.
+New downstream code should prefer the function-level API where possible.
+
+Current Migration Status
+------------------------
+
+Already migrated in this branch:
+
+- box local-to-world conversion
+- observer HPC/HCC projection for box corners
+- inscribing FOV and observer-aligned FOV-box computation
+- saved ``fov_box`` world-corner reconstruction
+- field-line projection in the 2D viewer
+- FOV-box projected edge and front-face overlays in the 2D viewer
+
+Still intentionally wrapper-backed:
+
+- existing gxbox box methods remain available and delegate into the public core
+- public observer helpers currently forward to the tested gxbox observer module
+
+Deferred until after pyAMPP merge:
+
+- replacing gximagecomputing's local Python geometry implementation with imports
+  from ``pyampp.geometry``
+
+Function Contracts
+------------------
+
+``local_cartesian_to_world(local_points_mm, frame, z_base_mm=0.0)``
+
+- Input: an ``(N, 3)`` array of local Cartesian points in Mm
+- Output: a vectorized ``SkyCoord`` in the supplied world frame
+- Returns ``None`` when inputs are missing or invalid
+
+``project_world_to_observer_hpc(world, observer=None, obstime=None, frame_obs=None)``
+
+- Input: any vectorized coordinates with a meaningful frame
+- Output: helioprojective coordinates for the resolved observer frame
+- Returns ``None`` when the observer context cannot be resolved
+
+``compute_inscribing_fov_from_world(world, ...)``
+
+- Input: arbitrary 3D world-space point set
+- Output: smallest axis-aligned observer HPC rectangle covering the projected points
+- Returns a dictionary with center, extent, bounds, and projected coordinates
+
+``compute_inscribing_fov_box_from_world(world, ...)``
+
+- Input: arbitrary 3D world-space point set
+- Output: observer-aligned 3D ``fov_box`` metadata with 2D footprint and Z extent
+- Z padding remains explicit through ``pad_z_frac``
+
+``observer_fov_box_to_world_corners(...)``
+
+- Input: saved observer ``fov_box`` metadata and target frame
+- Output: 8 reconstructed world-space corners suitable for reprojection or parity checks
+
+``observer_rectangle_to_hpc_corners(...)``
+
+- Input: observer-centered 2D rectangle definition in arcsec
+- Output: 4 helioprojective rectangle corners in the specified observer frame
+
+``project_coordinate_edges_to_observer_hpc(coords, edge_pairs, ...)``
+
+- Input: vectorized coordinates and an edge-pair list
+- Output: list of projected 2-point ``SkyCoord`` edges in observer HPC
+- Intended for box overlays and arbitrary polyline edge sets
+
+``project_box_front_face_to_observer_hpc(world_corners, ...)``
+
+- Input: 8 world-space box corners
+- Output: the observer-nearest projected face as a closed 5-point ``SkyCoord`` polygon
+
+``project_world_to_pixel(world, smap)``
+
+- Input: vectorized world coordinates and a SunPy map
+- Output: two NumPy arrays ``(x, y)`` in pixel coordinates
+
+Examples
+--------
+
+Convert local model points to world coordinates:
+
+.. code-block:: python
+
+   world = local_cartesian_to_world(local_points_mm, frame=box_center.frame, z_base_mm=grid_z_base)
+
+Project arbitrary 3D points into an observer image plane:
+
+.. code-block:: python
+
+   coords_hpc = project_world_to_observer_hpc(world, frame_obs=frame_obs)
+   xpix, ypix = project_world_to_pixel(coords_hpc, smap)
+
+Compute an inscribing 2D FOV or 3D FOV-box from one vectorized point set:
+
+.. code-block:: python
+
+   fov = compute_inscribing_fov_from_world(world, frame_obs=frame_obs)
+   fov_box = compute_inscribing_fov_box_from_world(world, frame_obs=frame_obs)
+
+Reconstruct and reproject a saved observer ``fov_box``:
+
+.. code-block:: python
+
+   corners_world = observer_fov_box_to_world_corners(
+       xc_arcsec=meta["xc_arcsec"],
+       yc_arcsec=meta["yc_arcsec"],
+       xsize_arcsec=meta["xsize_arcsec"],
+       ysize_arcsec=meta["ysize_arcsec"],
+       zmin_mm=meta["zmin_mm"],
+       zmax_mm=meta["zmax_mm"],
+       observer=observer,
+       obstime=obs_time,
+       target_frame=box_center.frame,
+   )
+   face = project_box_front_face_to_observer_hpc(corners_world, frame_obs=frame_obs)
+
+Reviewer Notes
+--------------
+
+The intended review standard for this PR is behavioral parity with the current
+gxbox workflows, not a broad geometry rewrite. The public API is designed to be
+adopted downstream first, then become the single shared geometry path in later
+repo updates.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ This is the documentation for pyAMPP.
    :caption: Contents:
 
    model_hdf5_format
+   geometry_api
    gx_fov2box_usage
    gui_workflow
    viewers

--- a/pyampp/__init__.py
+++ b/pyampp/__init__.py
@@ -1,3 +1,3 @@
-from . import sfq
+from . import geometry, sfq
 
-__all__ = ["sfq"]
+__all__ = ["geometry", "sfq"]

--- a/pyampp/geometry/__init__.py
+++ b/pyampp/geometry/__init__.py
@@ -1,0 +1,54 @@
+"""Public geometry import surface for pyAMPP.
+
+This package promotes the existing gxbox geometry and observer helpers into a
+headless, reusable module that other pyAMPP components and external consumers
+can import without depending on the gxbox viewer entrypoints.
+"""
+
+from .core import (
+    Box,
+    BoxGeometryMixin,
+    compute_inscribing_fov_box_from_world,
+    compute_inscribing_fov_from_hpc,
+    compute_inscribing_fov_from_world,
+    local_cartesian_to_world,
+    observer_fov_box_to_world_corners,
+    observer_rectangle_to_hpc_corners,
+    project_box_front_face_to_observer_hpc,
+    project_coordinate_edges_to_observer_hpc,
+    project_world_to_observer_hcc,
+    project_world_to_observer_hpc,
+    project_world_to_pixel,
+)
+from .observer import (
+    build_ephemeris_from_pb0r,
+    build_pb0r_metadata_from_ephemeris,
+    normalize_observer_key,
+    resolve_named_observer,
+    resolve_observer_from_metadata,
+    resolve_observer_with_info,
+    resolve_sdo_observer_from_b3d,
+)
+
+__all__ = [
+    "Box",
+    "BoxGeometryMixin",
+    "compute_inscribing_fov_box_from_world",
+    "compute_inscribing_fov_from_hpc",
+    "compute_inscribing_fov_from_world",
+    "local_cartesian_to_world",
+    "observer_fov_box_to_world_corners",
+    "observer_rectangle_to_hpc_corners",
+    "project_box_front_face_to_observer_hpc",
+    "project_coordinate_edges_to_observer_hpc",
+    "project_world_to_observer_hcc",
+    "project_world_to_observer_hpc",
+    "project_world_to_pixel",
+    "build_ephemeris_from_pb0r",
+    "build_pb0r_metadata_from_ephemeris",
+    "normalize_observer_key",
+    "resolve_named_observer",
+    "resolve_observer_from_metadata",
+    "resolve_observer_with_info",
+    "resolve_sdo_observer_from_b3d",
+]

--- a/pyampp/geometry/__init__.py
+++ b/pyampp/geometry/__init__.py
@@ -6,8 +6,6 @@ can import without depending on the gxbox viewer entrypoints.
 """
 
 from .core import (
-    Box,
-    BoxGeometryMixin,
     compute_inscribing_fov_box_from_world,
     compute_inscribing_fov_from_hpc,
     compute_inscribing_fov_from_world,
@@ -31,8 +29,6 @@ from .observer import (
 )
 
 __all__ = [
-    "Box",
-    "BoxGeometryMixin",
     "compute_inscribing_fov_box_from_world",
     "compute_inscribing_fov_from_hpc",
     "compute_inscribing_fov_from_world",
@@ -51,4 +47,18 @@ __all__ = [
     "resolve_observer_from_metadata",
     "resolve_observer_with_info",
     "resolve_sdo_observer_from_b3d",
+    "Box",
+    "BoxGeometryMixin",
 ]
+
+
+def __getattr__(name: str):
+    if name in {"Box", "BoxGeometryMixin"}:
+        from .core import Box, BoxGeometryMixin
+
+        exports = {
+            "Box": Box,
+            "BoxGeometryMixin": BoxGeometryMixin,
+        }
+        return exports[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pyampp/geometry/core.py
+++ b/pyampp/geometry/core.py
@@ -15,389 +15,387 @@ from astropy.coordinates import SkyCoord
 from sunpy.coordinates import Heliocentric, Helioprojective
 
 if TYPE_CHECKING:  # pragma: no cover
-	from pyampp.gxbox.box import Box, BoxGeometryMixin
+    from pyampp.gxbox.box import Box, BoxGeometryMixin
 
 
 def local_cartesian_to_world(
-	local_points_mm: np.ndarray,
-	*,
-	frame,
-	z_base_mm: float = 0.0,
+    local_points_mm: np.ndarray,
+    *,
+    frame,
+    z_base_mm: float = 0.0,
 ) -> SkyCoord | None:
-	"""Convert model-local Cartesian points into world-frame coordinates."""
-	if frame is None:
-		return None
-	try:
-		rows = np.asarray(local_points_mm, dtype=float)
-	except Exception:
-		return None
-	if rows.ndim != 2 or rows.shape[1] != 3 or rows.shape[0] == 0:
-		return None
-	finite = np.all(np.isfinite(rows), axis=1)
-	if not np.any(finite):
-		return None
-	rows = rows[finite]
-	try:
-		return SkyCoord(
-			x=rows[:, 0] * u.Mm,
-			y=rows[:, 1] * u.Mm,
-			z=(rows[:, 2] + float(z_base_mm)) * u.Mm,
-			frame=frame,
-		)
-	except Exception:
-		return None
+    """Convert model-local Cartesian points into world-frame coordinates."""
+    if frame is None:
+        return None
+    try:
+        rows = np.asarray(local_points_mm, dtype=float)
+    except Exception:
+        return None
+    if rows.ndim != 2 or rows.shape[1] != 3 or rows.shape[0] == 0:
+        return None
+    if not np.all(np.isfinite(rows)):
+        return None
+    try:
+        return SkyCoord(
+            x=rows[:, 0] * u.Mm,
+            y=rows[:, 1] * u.Mm,
+            z=(rows[:, 2] + float(z_base_mm)) * u.Mm,
+            frame=frame,
+        )
+    except Exception:
+        return None
 
 
 def project_world_to_observer_hpc(
-	world: SkyCoord,
-	*,
-	observer=None,
-	obstime=None,
-	frame_obs=None,
+    world: SkyCoord,
+    *,
+    observer=None,
+    obstime=None,
+    frame_obs=None,
 ) -> SkyCoord | None:
-	"""Project world coordinates into the observer helioprojective frame."""
-	if world is None:
-		return None
-	world_frame = getattr(world, "frame", None)
-	if observer is None and frame_obs is not None:
-		observer = getattr(frame_obs, "observer", None)
-	if observer is None and world_frame is not None:
-		observer = getattr(world_frame, "observer", None)
-	if obstime is None and frame_obs is not None:
-		obstime = getattr(frame_obs, "obstime", None)
-	if obstime is None and world_frame is not None:
-		obstime = getattr(world_frame, "obstime", None)
-	if observer is None:
-		return None
-	try:
-		return world.transform_to(Helioprojective(observer=observer, obstime=obstime))
-	except Exception:
-		return None
+    """Project world coordinates into the observer helioprojective frame."""
+    if world is None:
+        return None
+    world_frame = getattr(world, "frame", None)
+    if observer is None and frame_obs is not None:
+        observer = getattr(frame_obs, "observer", None)
+    if observer is None and world_frame is not None:
+        observer = getattr(world_frame, "observer", None)
+    if obstime is None and frame_obs is not None:
+        obstime = getattr(frame_obs, "obstime", None)
+    if obstime is None and world_frame is not None:
+        obstime = getattr(world_frame, "obstime", None)
+    if observer is None:
+        return None
+    try:
+        return world.transform_to(Helioprojective(observer=observer, obstime=obstime))
+    except Exception:
+        return None
 
 
 def project_world_to_observer_hcc(
-	world: SkyCoord,
-	*,
-	observer=None,
-	obstime=None,
-	frame_obs=None,
+    world: SkyCoord,
+    *,
+    observer=None,
+    obstime=None,
+    frame_obs=None,
 ) -> SkyCoord | None:
-	"""Project world coordinates into the observer-centric heliocentric frame."""
-	if world is None:
-		return None
-	world_frame = getattr(world, "frame", None)
-	if observer is None and frame_obs is not None:
-		observer = getattr(frame_obs, "observer", None)
-	if observer is None and world_frame is not None:
-		observer = getattr(world_frame, "observer", None)
-	if obstime is None and frame_obs is not None:
-		obstime = getattr(frame_obs, "obstime", None)
-	if obstime is None and world_frame is not None:
-		obstime = getattr(world_frame, "obstime", None)
-	if observer is None:
-		return None
-	try:
-		return world.transform_to(Heliocentric(observer=observer, obstime=obstime))
-	except Exception:
-		return None
+    """Project world coordinates into the observer-centric heliocentric frame."""
+    if world is None:
+        return None
+    world_frame = getattr(world, "frame", None)
+    if observer is None and frame_obs is not None:
+        observer = getattr(frame_obs, "observer", None)
+    if observer is None and world_frame is not None:
+        observer = getattr(world_frame, "observer", None)
+    if obstime is None and frame_obs is not None:
+        obstime = getattr(frame_obs, "obstime", None)
+    if obstime is None and world_frame is not None:
+        obstime = getattr(world_frame, "obstime", None)
+    if observer is None:
+        return None
+    try:
+        return world.transform_to(Heliocentric(observer=observer, obstime=obstime))
+    except Exception:
+        return None
 
 
 def compute_inscribing_fov_from_hpc(
-	coords_hpc: SkyCoord,
-	*,
-	pad_arcsec: float = 0.0,
+    coords_hpc: SkyCoord,
+    *,
+    pad_arcsec: float = 0.0,
 ) -> dict | None:
-	"""Compute the smallest axis-aligned HPC rectangle covering the inputs."""
-	if coords_hpc is None:
-		return None
-	try:
-		tx = np.asarray(coords_hpc.Tx.to_value(u.arcsec), dtype=float)
-		ty = np.asarray(coords_hpc.Ty.to_value(u.arcsec), dtype=float)
-	except Exception:
-		return None
-	if tx.size == 0 or ty.size == 0:
-		return None
-	finite = np.isfinite(tx) & np.isfinite(ty)
-	if not np.any(finite):
-		return None
-	tx = tx[finite]
-	ty = ty[finite]
-	pad = max(float(pad_arcsec), 0.0)
-	xmin = float(np.min(tx)) - pad
-	xmax = float(np.max(tx)) + pad
-	ymin = float(np.min(ty)) - pad
-	ymax = float(np.max(ty)) + pad
-	return {
-		"xc_arcsec": 0.5 * (xmin + xmax),
-		"yc_arcsec": 0.5 * (ymin + ymax),
-		"xsize_arcsec": xmax - xmin,
-		"ysize_arcsec": ymax - ymin,
-		"xmin_arcsec": xmin,
-		"xmax_arcsec": xmax,
-		"ymin_arcsec": ymin,
-		"ymax_arcsec": ymax,
-		"corners_hpc": coords_hpc,
-	}
+    """Compute the smallest axis-aligned HPC rectangle covering the inputs."""
+    if coords_hpc is None:
+        return None
+    try:
+        tx = np.asarray(coords_hpc.Tx.to_value(u.arcsec), dtype=float)
+        ty = np.asarray(coords_hpc.Ty.to_value(u.arcsec), dtype=float)
+    except Exception:
+        return None
+    if tx.size == 0 or ty.size == 0:
+        return None
+    finite = np.isfinite(tx) & np.isfinite(ty)
+    if not np.any(finite):
+        return None
+    tx = tx[finite]
+    ty = ty[finite]
+    pad = max(float(pad_arcsec), 0.0)
+    xmin = float(np.min(tx)) - pad
+    xmax = float(np.max(tx)) + pad
+    ymin = float(np.min(ty)) - pad
+    ymax = float(np.max(ty)) + pad
+    return {
+        "xc_arcsec": 0.5 * (xmin + xmax),
+        "yc_arcsec": 0.5 * (ymin + ymax),
+        "xsize_arcsec": xmax - xmin,
+        "ysize_arcsec": ymax - ymin,
+        "xmin_arcsec": xmin,
+        "xmax_arcsec": xmax,
+        "ymin_arcsec": ymin,
+        "ymax_arcsec": ymax,
+        "corners_hpc": coords_hpc,
+    }
 
 
 def compute_inscribing_fov_from_world(
-	world: SkyCoord,
-	*,
-	observer=None,
-	obstime=None,
-	frame_obs=None,
-	pad_arcsec: float = 0.0,
+    world: SkyCoord,
+    *,
+    observer=None,
+    obstime=None,
+    frame_obs=None,
+    pad_arcsec: float = 0.0,
 ) -> dict | None:
-	"""Project world coordinates and compute the enclosing 2D observer FOV."""
-	coords_hpc = project_world_to_observer_hpc(
-		world,
-		observer=observer,
-		obstime=obstime,
-		frame_obs=frame_obs,
-	)
-	return compute_inscribing_fov_from_hpc(coords_hpc, pad_arcsec=pad_arcsec)
+    """Project world coordinates and compute the enclosing 2D observer FOV."""
+    coords_hpc = project_world_to_observer_hpc(
+        world,
+        observer=observer,
+        obstime=obstime,
+        frame_obs=frame_obs,
+    )
+    return compute_inscribing_fov_from_hpc(coords_hpc, pad_arcsec=pad_arcsec)
 
 
 def compute_inscribing_fov_box_from_world(
-	world: SkyCoord,
-	*,
-	observer=None,
-	obstime=None,
-	frame_obs=None,
-	pad_xy_arcsec: float = 0.0,
-	pad_z_frac: float = 0.10,
+    world: SkyCoord,
+    *,
+    observer=None,
+    obstime=None,
+    frame_obs=None,
+    pad_xy_arcsec: float = 0.0,
+    pad_z_frac: float = 0.10,
 ) -> dict | None:
-	"""Compute the observer-aligned 3D FOV box enclosing the inputs."""
-	footprint = compute_inscribing_fov_from_world(
-		world,
-		observer=observer,
-		obstime=obstime,
-		frame_obs=frame_obs,
-		pad_arcsec=pad_xy_arcsec,
-	)
-	if footprint is None:
-		return None
-	coords_hcc = project_world_to_observer_hcc(
-		world,
-		observer=observer,
-		obstime=obstime,
-		frame_obs=frame_obs,
-	)
-	if coords_hcc is None:
-		return None
-	try:
-		z_vals = np.asarray(coords_hcc.z.to_value(u.Mm), dtype=float)
-	except Exception:
-		return None
-	finite = np.isfinite(z_vals)
-	if not np.any(finite):
-		return None
-	z_vals = z_vals[finite]
-	z_min = float(np.nanmin(z_vals))
-	z_max = float(np.nanmax(z_vals))
-	z_span = max(1e-6, z_max - z_min)
-	z_pad = max(0.0, float(pad_z_frac)) * z_span
-	result = dict(footprint)
-	result.update({
-		"zmin_mm": z_min - z_pad,
-		"zmax_mm": z_max + z_pad,
-	})
-	return result
+    """Compute the observer-aligned 3D FOV box enclosing the inputs."""
+    footprint = compute_inscribing_fov_from_world(
+        world,
+        observer=observer,
+        obstime=obstime,
+        frame_obs=frame_obs,
+        pad_arcsec=pad_xy_arcsec,
+    )
+    if footprint is None:
+        return None
+    coords_hcc = project_world_to_observer_hcc(
+        world,
+        observer=observer,
+        obstime=obstime,
+        frame_obs=frame_obs,
+    )
+    if coords_hcc is None:
+        return None
+    try:
+        z_vals = np.asarray(coords_hcc.z.to_value(u.Mm), dtype=float)
+    except Exception:
+        return None
+    finite = np.isfinite(z_vals)
+    if not np.any(finite):
+        return None
+    z_vals = z_vals[finite]
+    z_min = float(np.nanmin(z_vals))
+    z_max = float(np.nanmax(z_vals))
+    z_span = max(1e-6, z_max - z_min)
+    z_pad = max(0.0, float(pad_z_frac)) * z_span
+    result = dict(footprint)
+    result.update({
+        "zmin_mm": z_min - z_pad,
+        "zmax_mm": z_max + z_pad,
+    })
+    return result
 
 
 def observer_fov_box_to_world_corners(
-	*,
-	xc_arcsec: float,
-	yc_arcsec: float,
-	xsize_arcsec: float,
-	ysize_arcsec: float,
-	zmin_mm: float,
-	zmax_mm: float,
-	observer,
-	obstime,
-	target_frame,
+    *,
+    xc_arcsec: float,
+    yc_arcsec: float,
+    xsize_arcsec: float,
+    ysize_arcsec: float,
+    zmin_mm: float,
+    zmax_mm: float,
+    observer,
+    obstime,
+    target_frame,
 ) -> SkyCoord | None:
-	"""Reconstruct 8 world-space corners from saved observer `fov_box` metadata."""
-	if observer is None or target_frame is None:
-		return None
-	try:
-		dsun_mm = float(observer.radius.to_value(u.Mm))
-	except Exception:
-		return None
-	half_w = 0.5 * max(float(xsize_arcsec), 1e-6)
-	half_h = 0.5 * max(float(ysize_arcsec), 1e-6)
-	frame_hpc = Helioprojective(observer=observer, obstime=obstime)
-	points = np.asarray(
-		[
-			[float(xc_arcsec) - half_w, float(yc_arcsec) - half_h, float(zmin_mm)],
-			[float(xc_arcsec) + half_w, float(yc_arcsec) - half_h, float(zmin_mm)],
-			[float(xc_arcsec) - half_w, float(yc_arcsec) + half_h, float(zmin_mm)],
-			[float(xc_arcsec) + half_w, float(yc_arcsec) + half_h, float(zmin_mm)],
-			[float(xc_arcsec) - half_w, float(yc_arcsec) - half_h, float(zmax_mm)],
-			[float(xc_arcsec) + half_w, float(yc_arcsec) - half_h, float(zmax_mm)],
-			[float(xc_arcsec) - half_w, float(yc_arcsec) + half_h, float(zmax_mm)],
-			[float(xc_arcsec) + half_w, float(yc_arcsec) + half_h, float(zmax_mm)],
-		],
-		dtype=float,
-	)
-	distances = dsun_mm - points[:, 2]
-	if not np.all(np.isfinite(distances)) or np.any(distances <= 0):
-		return None
-	try:
-		corners_hpc = SkyCoord(
-			Tx=points[:, 0] * u.arcsec,
-			Ty=points[:, 1] * u.arcsec,
-			distance=distances * u.Mm,
-			frame=frame_hpc,
-		)
-		return corners_hpc.transform_to(target_frame)
-	except Exception:
-		return None
+    """Reconstruct 8 world-space corners from saved observer `fov_box` metadata."""
+    if observer is None or target_frame is None:
+        return None
+    try:
+        dsun_mm = float(observer.radius.to_value(u.Mm))
+    except Exception:
+        return None
+    half_w = 0.5 * max(float(xsize_arcsec), 1e-6)
+    half_h = 0.5 * max(float(ysize_arcsec), 1e-6)
+    frame_hpc = Helioprojective(observer=observer, obstime=obstime)
+    points = np.asarray(
+        [
+            [float(xc_arcsec) - half_w, float(yc_arcsec) - half_h, float(zmin_mm)],
+            [float(xc_arcsec) + half_w, float(yc_arcsec) - half_h, float(zmin_mm)],
+            [float(xc_arcsec) - half_w, float(yc_arcsec) + half_h, float(zmin_mm)],
+            [float(xc_arcsec) + half_w, float(yc_arcsec) + half_h, float(zmin_mm)],
+            [float(xc_arcsec) - half_w, float(yc_arcsec) - half_h, float(zmax_mm)],
+            [float(xc_arcsec) + half_w, float(yc_arcsec) - half_h, float(zmax_mm)],
+            [float(xc_arcsec) - half_w, float(yc_arcsec) + half_h, float(zmax_mm)],
+            [float(xc_arcsec) + half_w, float(yc_arcsec) + half_h, float(zmax_mm)],
+        ],
+        dtype=float,
+    )
+    distances = dsun_mm - points[:, 2]
+    if not np.all(np.isfinite(distances)) or np.any(distances <= 0):
+        return None
+    try:
+        corners_hpc = SkyCoord(
+            Tx=points[:, 0] * u.arcsec,
+            Ty=points[:, 1] * u.arcsec,
+            distance=distances * u.Mm,
+            frame=frame_hpc,
+        )
+        return corners_hpc.transform_to(target_frame)
+    except Exception:
+        return None
 
 
 def observer_rectangle_to_hpc_corners(
-	*,
-	xc_arcsec: float,
-	yc_arcsec: float,
-	xsize_arcsec: float,
-	ysize_arcsec: float,
-	observer,
-	obstime,
+    *,
+    xc_arcsec: float,
+    yc_arcsec: float,
+    xsize_arcsec: float,
+    ysize_arcsec: float,
+    observer,
+    obstime,
 ) -> SkyCoord | None:
-	"""Construct 4 helioprojective rectangle corners for an observer view."""
-	if observer is None:
-		return None
-	half_w = 0.5 * max(float(xsize_arcsec), 1e-6)
-	half_h = 0.5 * max(float(ysize_arcsec), 1e-6)
-	try:
-		return SkyCoord(
-			Tx=np.asarray(
-				[
-					float(xc_arcsec) - half_w,
-					float(xc_arcsec) + half_w,
-					float(xc_arcsec) - half_w,
-					float(xc_arcsec) + half_w,
-				],
-				dtype=float,
-			)
-			* u.arcsec,
-			Ty=np.asarray(
-				[
-					float(yc_arcsec) - half_h,
-					float(yc_arcsec) - half_h,
-					float(yc_arcsec) + half_h,
-					float(yc_arcsec) + half_h,
-				],
-				dtype=float,
-			)
-			* u.arcsec,
-			frame=Helioprojective(observer=observer, obstime=obstime),
-		)
-	except Exception:
-		return None
+    """Construct 4 helioprojective rectangle corners for an observer view."""
+    if observer is None:
+        return None
+    half_w = 0.5 * max(float(xsize_arcsec), 1e-6)
+    half_h = 0.5 * max(float(ysize_arcsec), 1e-6)
+    try:
+        return SkyCoord(
+            Tx=np.asarray(
+                [
+                    float(xc_arcsec) - half_w,
+                    float(xc_arcsec) + half_w,
+                    float(xc_arcsec) - half_w,
+                    float(xc_arcsec) + half_w,
+                ],
+                dtype=float,
+            )
+            * u.arcsec,
+            Ty=np.asarray(
+                [
+                    float(yc_arcsec) - half_h,
+                    float(yc_arcsec) - half_h,
+                    float(yc_arcsec) + half_h,
+                    float(yc_arcsec) + half_h,
+                ],
+                dtype=float,
+            )
+            * u.arcsec,
+            frame=Helioprojective(observer=observer, obstime=obstime),
+        )
+    except Exception:
+        return None
 
 
 def project_coordinate_edges_to_observer_hpc(
-	coords,
-	*,
-	edge_pairs,
-	observer=None,
-	obstime=None,
-	frame_obs=None,
+    coords,
+    *,
+    edge_pairs,
+    observer=None,
+    obstime=None,
+    frame_obs=None,
 ) -> list[SkyCoord] | None:
-	"""Project coordinate edge pairs into one observer helioprojective frame."""
-	if coords is None:
-		return None
-	try:
-		edges = []
-		for i, j in edge_pairs:
-			edge = SkyCoord([coords[int(i)], coords[int(j)]])
-			projected = project_world_to_observer_hpc(
-				edge,
-				observer=observer,
-				obstime=obstime,
-				frame_obs=frame_obs,
-			)
-			if projected is None:
-				return None
-			edges.append(projected)
-		return edges
-	except Exception:
-		return None
+    """Project coordinate edge pairs into one observer helioprojective frame."""
+    if coords is None:
+        return None
+    try:
+        edges = []
+        for i, j in edge_pairs:
+            edge = SkyCoord([coords[int(i)], coords[int(j)]])
+            projected = project_world_to_observer_hpc(
+                edge,
+                observer=observer,
+                obstime=obstime,
+                frame_obs=frame_obs,
+            )
+            if projected is None:
+                return None
+            edges.append(projected)
+        return edges
+    except Exception:
+        return None
 
 
 def project_box_front_face_to_observer_hpc(
-	world_corners: SkyCoord,
-	*,
-	observer=None,
-	obstime=None,
-	frame_obs=None,
-	front_face=(0, 1, 3, 2),
-	back_face=(4, 5, 7, 6),
+    world_corners: SkyCoord,
+    *,
+    observer=None,
+    obstime=None,
+    frame_obs=None,
+    front_face=(0, 1, 3, 2),
+    back_face=(4, 5, 7, 6),
 ) -> SkyCoord | None:
-	"""Project the nearer box face into the observer helioprojective frame."""
-	if world_corners is None:
-		return None
-	corners_obs = project_world_to_observer_hpc(
-		world_corners,
-		observer=observer,
-		obstime=obstime,
-		frame_obs=frame_obs,
-	)
-	if corners_obs is None:
-		return None
+    """Project the nearer box face into the observer helioprojective frame."""
+    if world_corners is None:
+        return None
+    corners_obs = project_world_to_observer_hpc(
+        world_corners,
+        observer=observer,
+        obstime=obstime,
+        frame_obs=frame_obs,
+    )
+    if corners_obs is None:
+        return None
 
-	def _mean_distance(indices) -> float:
-		try:
-			return float(np.nanmean(corners_obs[np.asarray(indices, dtype=int)].distance.to_value(u.Mm)))
-		except Exception:
-			return np.inf
+    def _mean_distance(indices) -> float:
+        try:
+            return float(np.nanmean(corners_obs[np.asarray(indices, dtype=int)].distance.to_value(u.Mm)))
+        except Exception:
+            return np.inf
 
-	face = np.asarray(front_face if _mean_distance(front_face) <= _mean_distance(back_face) else back_face, dtype=int)
-	try:
-		ordered = [corners_obs[int(i)] for i in face] + [corners_obs[int(face[0])]]
-		return SkyCoord(ordered)
-	except Exception:
-		return None
+    face = np.asarray(front_face if _mean_distance(front_face) <= _mean_distance(back_face) else back_face, dtype=int)
+    try:
+        ordered = [corners_obs[int(i)] for i in face] + [corners_obs[int(face[0])]]
+        return SkyCoord(ordered)
+    except Exception:
+        return None
 
 
 def project_world_to_pixel(world: SkyCoord, smap) -> tuple[np.ndarray, np.ndarray] | None:
-	"""Project world coordinates into a map's pixel plane in one vectorized call."""
-	if world is None or smap is None:
-		return None
-	try:
-		xpix, ypix = smap.world_to_pixel(world)
-		x = np.asarray(xpix.value if hasattr(xpix, "value") else xpix, dtype=float)
-		y = np.asarray(ypix.value if hasattr(ypix, "value") else ypix, dtype=float)
-	except Exception:
-		return None
-	return x, y
+    """Project world coordinates into a map's pixel plane in one vectorized call."""
+    if world is None or smap is None:
+        return None
+    try:
+        xpix, ypix = smap.world_to_pixel(world)
+        x = np.asarray(xpix.value if hasattr(xpix, "value") else xpix, dtype=float)
+        y = np.asarray(ypix.value if hasattr(ypix, "value") else ypix, dtype=float)
+    except Exception:
+        return None
+    return x, y
 
 
 def __getattr__(name: str):
-	if name in {"Box", "BoxGeometryMixin"}:
-		from pyampp.gxbox.box import Box, BoxGeometryMixin
+    if name in {"Box", "BoxGeometryMixin"}:
+        from pyampp.gxbox.box import Box, BoxGeometryMixin
 
-		exports = {
-			"Box": Box,
-			"BoxGeometryMixin": BoxGeometryMixin,
-		}
-		return exports[name]
-	raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        exports = {
+            "Box": Box,
+            "BoxGeometryMixin": BoxGeometryMixin,
+        }
+        return exports[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [
-	"local_cartesian_to_world",
-	"project_world_to_observer_hpc",
-	"project_world_to_observer_hcc",
-	"compute_inscribing_fov_from_hpc",
-	"compute_inscribing_fov_from_world",
-	"compute_inscribing_fov_box_from_world",
-	"observer_fov_box_to_world_corners",
-	"observer_rectangle_to_hpc_corners",
-	"project_coordinate_edges_to_observer_hpc",
-	"project_box_front_face_to_observer_hpc",
-	"project_world_to_pixel",
-	"Box",
-	"BoxGeometryMixin",
+    "local_cartesian_to_world",
+    "project_world_to_observer_hpc",
+    "project_world_to_observer_hcc",
+    "compute_inscribing_fov_from_hpc",
+    "compute_inscribing_fov_from_world",
+    "compute_inscribing_fov_box_from_world",
+    "observer_fov_box_to_world_corners",
+    "observer_rectangle_to_hpc_corners",
+    "project_coordinate_edges_to_observer_hpc",
+    "project_box_front_face_to_observer_hpc",
+    "project_world_to_pixel",
+    "Box",
+    "BoxGeometryMixin",
 ]

--- a/pyampp/geometry/core.py
+++ b/pyampp/geometry/core.py
@@ -1,0 +1,403 @@
+"""Public vectorized geometry primitives for pyAMPP.
+
+The gxbox tools historically carried the proven geometry implementation inside
+their application layer. This module promotes the reusable, headless pieces so
+all 3D structures can flow through the same world/observer projection path.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import SkyCoord
+from sunpy.coordinates import Heliocentric, Helioprojective
+
+if TYPE_CHECKING:  # pragma: no cover
+	from pyampp.gxbox.box import Box, BoxGeometryMixin
+
+
+def local_cartesian_to_world(
+	local_points_mm: np.ndarray,
+	*,
+	frame,
+	z_base_mm: float = 0.0,
+) -> SkyCoord | None:
+	"""Convert model-local Cartesian points into world-frame coordinates."""
+	if frame is None:
+		return None
+	try:
+		rows = np.asarray(local_points_mm, dtype=float)
+	except Exception:
+		return None
+	if rows.ndim != 2 or rows.shape[1] != 3 or rows.shape[0] == 0:
+		return None
+	finite = np.all(np.isfinite(rows), axis=1)
+	if not np.any(finite):
+		return None
+	rows = rows[finite]
+	try:
+		return SkyCoord(
+			x=rows[:, 0] * u.Mm,
+			y=rows[:, 1] * u.Mm,
+			z=(rows[:, 2] + float(z_base_mm)) * u.Mm,
+			frame=frame,
+		)
+	except Exception:
+		return None
+
+
+def project_world_to_observer_hpc(
+	world: SkyCoord,
+	*,
+	observer=None,
+	obstime=None,
+	frame_obs=None,
+) -> SkyCoord | None:
+	"""Project world coordinates into the observer helioprojective frame."""
+	if world is None:
+		return None
+	world_frame = getattr(world, "frame", None)
+	if observer is None and frame_obs is not None:
+		observer = getattr(frame_obs, "observer", None)
+	if observer is None and world_frame is not None:
+		observer = getattr(world_frame, "observer", None)
+	if obstime is None and frame_obs is not None:
+		obstime = getattr(frame_obs, "obstime", None)
+	if obstime is None and world_frame is not None:
+		obstime = getattr(world_frame, "obstime", None)
+	if observer is None:
+		return None
+	try:
+		return world.transform_to(Helioprojective(observer=observer, obstime=obstime))
+	except Exception:
+		return None
+
+
+def project_world_to_observer_hcc(
+	world: SkyCoord,
+	*,
+	observer=None,
+	obstime=None,
+	frame_obs=None,
+) -> SkyCoord | None:
+	"""Project world coordinates into the observer-centric heliocentric frame."""
+	if world is None:
+		return None
+	world_frame = getattr(world, "frame", None)
+	if observer is None and frame_obs is not None:
+		observer = getattr(frame_obs, "observer", None)
+	if observer is None and world_frame is not None:
+		observer = getattr(world_frame, "observer", None)
+	if obstime is None and frame_obs is not None:
+		obstime = getattr(frame_obs, "obstime", None)
+	if obstime is None and world_frame is not None:
+		obstime = getattr(world_frame, "obstime", None)
+	if observer is None:
+		return None
+	try:
+		return world.transform_to(Heliocentric(observer=observer, obstime=obstime))
+	except Exception:
+		return None
+
+
+def compute_inscribing_fov_from_hpc(
+	coords_hpc: SkyCoord,
+	*,
+	pad_arcsec: float = 0.0,
+) -> dict | None:
+	"""Compute the smallest axis-aligned HPC rectangle covering the inputs."""
+	if coords_hpc is None:
+		return None
+	try:
+		tx = np.asarray(coords_hpc.Tx.to_value(u.arcsec), dtype=float)
+		ty = np.asarray(coords_hpc.Ty.to_value(u.arcsec), dtype=float)
+	except Exception:
+		return None
+	if tx.size == 0 or ty.size == 0:
+		return None
+	finite = np.isfinite(tx) & np.isfinite(ty)
+	if not np.any(finite):
+		return None
+	tx = tx[finite]
+	ty = ty[finite]
+	pad = max(float(pad_arcsec), 0.0)
+	xmin = float(np.min(tx)) - pad
+	xmax = float(np.max(tx)) + pad
+	ymin = float(np.min(ty)) - pad
+	ymax = float(np.max(ty)) + pad
+	return {
+		"xc_arcsec": 0.5 * (xmin + xmax),
+		"yc_arcsec": 0.5 * (ymin + ymax),
+		"xsize_arcsec": xmax - xmin,
+		"ysize_arcsec": ymax - ymin,
+		"xmin_arcsec": xmin,
+		"xmax_arcsec": xmax,
+		"ymin_arcsec": ymin,
+		"ymax_arcsec": ymax,
+		"corners_hpc": coords_hpc,
+	}
+
+
+def compute_inscribing_fov_from_world(
+	world: SkyCoord,
+	*,
+	observer=None,
+	obstime=None,
+	frame_obs=None,
+	pad_arcsec: float = 0.0,
+) -> dict | None:
+	"""Project world coordinates and compute the enclosing 2D observer FOV."""
+	coords_hpc = project_world_to_observer_hpc(
+		world,
+		observer=observer,
+		obstime=obstime,
+		frame_obs=frame_obs,
+	)
+	return compute_inscribing_fov_from_hpc(coords_hpc, pad_arcsec=pad_arcsec)
+
+
+def compute_inscribing_fov_box_from_world(
+	world: SkyCoord,
+	*,
+	observer=None,
+	obstime=None,
+	frame_obs=None,
+	pad_xy_arcsec: float = 0.0,
+	pad_z_frac: float = 0.10,
+) -> dict | None:
+	"""Compute the observer-aligned 3D FOV box enclosing the inputs."""
+	footprint = compute_inscribing_fov_from_world(
+		world,
+		observer=observer,
+		obstime=obstime,
+		frame_obs=frame_obs,
+		pad_arcsec=pad_xy_arcsec,
+	)
+	if footprint is None:
+		return None
+	coords_hcc = project_world_to_observer_hcc(
+		world,
+		observer=observer,
+		obstime=obstime,
+		frame_obs=frame_obs,
+	)
+	if coords_hcc is None:
+		return None
+	try:
+		z_vals = np.asarray(coords_hcc.z.to_value(u.Mm), dtype=float)
+	except Exception:
+		return None
+	finite = np.isfinite(z_vals)
+	if not np.any(finite):
+		return None
+	z_vals = z_vals[finite]
+	z_min = float(np.nanmin(z_vals))
+	z_max = float(np.nanmax(z_vals))
+	z_span = max(1e-6, z_max - z_min)
+	z_pad = max(0.0, float(pad_z_frac)) * z_span
+	result = dict(footprint)
+	result.update({
+		"zmin_mm": z_min - z_pad,
+		"zmax_mm": z_max + z_pad,
+	})
+	return result
+
+
+def observer_fov_box_to_world_corners(
+	*,
+	xc_arcsec: float,
+	yc_arcsec: float,
+	xsize_arcsec: float,
+	ysize_arcsec: float,
+	zmin_mm: float,
+	zmax_mm: float,
+	observer,
+	obstime,
+	target_frame,
+) -> SkyCoord | None:
+	"""Reconstruct 8 world-space corners from saved observer `fov_box` metadata."""
+	if observer is None or target_frame is None:
+		return None
+	try:
+		dsun_mm = float(observer.radius.to_value(u.Mm))
+	except Exception:
+		return None
+	half_w = 0.5 * max(float(xsize_arcsec), 1e-6)
+	half_h = 0.5 * max(float(ysize_arcsec), 1e-6)
+	frame_hpc = Helioprojective(observer=observer, obstime=obstime)
+	points = np.asarray(
+		[
+			[float(xc_arcsec) - half_w, float(yc_arcsec) - half_h, float(zmin_mm)],
+			[float(xc_arcsec) + half_w, float(yc_arcsec) - half_h, float(zmin_mm)],
+			[float(xc_arcsec) - half_w, float(yc_arcsec) + half_h, float(zmin_mm)],
+			[float(xc_arcsec) + half_w, float(yc_arcsec) + half_h, float(zmin_mm)],
+			[float(xc_arcsec) - half_w, float(yc_arcsec) - half_h, float(zmax_mm)],
+			[float(xc_arcsec) + half_w, float(yc_arcsec) - half_h, float(zmax_mm)],
+			[float(xc_arcsec) - half_w, float(yc_arcsec) + half_h, float(zmax_mm)],
+			[float(xc_arcsec) + half_w, float(yc_arcsec) + half_h, float(zmax_mm)],
+		],
+		dtype=float,
+	)
+	distances = dsun_mm - points[:, 2]
+	if not np.all(np.isfinite(distances)) or np.any(distances <= 0):
+		return None
+	try:
+		corners_hpc = SkyCoord(
+			Tx=points[:, 0] * u.arcsec,
+			Ty=points[:, 1] * u.arcsec,
+			distance=distances * u.Mm,
+			frame=frame_hpc,
+		)
+		return corners_hpc.transform_to(target_frame)
+	except Exception:
+		return None
+
+
+def observer_rectangle_to_hpc_corners(
+	*,
+	xc_arcsec: float,
+	yc_arcsec: float,
+	xsize_arcsec: float,
+	ysize_arcsec: float,
+	observer,
+	obstime,
+) -> SkyCoord | None:
+	"""Construct 4 helioprojective rectangle corners for an observer view."""
+	if observer is None:
+		return None
+	half_w = 0.5 * max(float(xsize_arcsec), 1e-6)
+	half_h = 0.5 * max(float(ysize_arcsec), 1e-6)
+	try:
+		return SkyCoord(
+			Tx=np.asarray(
+				[
+					float(xc_arcsec) - half_w,
+					float(xc_arcsec) + half_w,
+					float(xc_arcsec) - half_w,
+					float(xc_arcsec) + half_w,
+				],
+				dtype=float,
+			)
+			* u.arcsec,
+			Ty=np.asarray(
+				[
+					float(yc_arcsec) - half_h,
+					float(yc_arcsec) - half_h,
+					float(yc_arcsec) + half_h,
+					float(yc_arcsec) + half_h,
+				],
+				dtype=float,
+			)
+			* u.arcsec,
+			frame=Helioprojective(observer=observer, obstime=obstime),
+		)
+	except Exception:
+		return None
+
+
+def project_coordinate_edges_to_observer_hpc(
+	coords,
+	*,
+	edge_pairs,
+	observer=None,
+	obstime=None,
+	frame_obs=None,
+) -> list[SkyCoord] | None:
+	"""Project coordinate edge pairs into one observer helioprojective frame."""
+	if coords is None:
+		return None
+	try:
+		edges = []
+		for i, j in edge_pairs:
+			edge = SkyCoord([coords[int(i)], coords[int(j)]])
+			projected = project_world_to_observer_hpc(
+				edge,
+				observer=observer,
+				obstime=obstime,
+				frame_obs=frame_obs,
+			)
+			if projected is None:
+				return None
+			edges.append(projected)
+		return edges
+	except Exception:
+		return None
+
+
+def project_box_front_face_to_observer_hpc(
+	world_corners: SkyCoord,
+	*,
+	observer=None,
+	obstime=None,
+	frame_obs=None,
+	front_face=(0, 1, 3, 2),
+	back_face=(4, 5, 7, 6),
+) -> SkyCoord | None:
+	"""Project the nearer box face into the observer helioprojective frame."""
+	if world_corners is None:
+		return None
+	corners_obs = project_world_to_observer_hpc(
+		world_corners,
+		observer=observer,
+		obstime=obstime,
+		frame_obs=frame_obs,
+	)
+	if corners_obs is None:
+		return None
+
+	def _mean_distance(indices) -> float:
+		try:
+			return float(np.nanmean(corners_obs[np.asarray(indices, dtype=int)].distance.to_value(u.Mm)))
+		except Exception:
+			return np.inf
+
+	face = np.asarray(front_face if _mean_distance(front_face) <= _mean_distance(back_face) else back_face, dtype=int)
+	try:
+		ordered = [corners_obs[int(i)] for i in face] + [corners_obs[int(face[0])]]
+		return SkyCoord(ordered)
+	except Exception:
+		return None
+
+
+def project_world_to_pixel(world: SkyCoord, smap) -> tuple[np.ndarray, np.ndarray] | None:
+	"""Project world coordinates into a map's pixel plane in one vectorized call."""
+	if world is None or smap is None:
+		return None
+	try:
+		xpix, ypix = smap.world_to_pixel(world)
+		x = np.asarray(xpix.value if hasattr(xpix, "value") else xpix, dtype=float)
+		y = np.asarray(ypix.value if hasattr(ypix, "value") else ypix, dtype=float)
+	except Exception:
+		return None
+	return x, y
+
+
+def __getattr__(name: str):
+	if name in {"Box", "BoxGeometryMixin"}:
+		from pyampp.gxbox.box import Box, BoxGeometryMixin
+
+		exports = {
+			"Box": Box,
+			"BoxGeometryMixin": BoxGeometryMixin,
+		}
+		return exports[name]
+	raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+	"local_cartesian_to_world",
+	"project_world_to_observer_hpc",
+	"project_world_to_observer_hcc",
+	"compute_inscribing_fov_from_hpc",
+	"compute_inscribing_fov_from_world",
+	"compute_inscribing_fov_box_from_world",
+	"observer_fov_box_to_world_corners",
+	"observer_rectangle_to_hpc_corners",
+	"project_coordinate_edges_to_observer_hpc",
+	"project_box_front_face_to_observer_hpc",
+	"project_world_to_pixel",
+	"Box",
+	"BoxGeometryMixin",
+]

--- a/pyampp/geometry/observer.py
+++ b/pyampp/geometry/observer.py
@@ -1,0 +1,26 @@
+"""Promoted observer-resolution helpers for geometry workflows.
+
+These functions remain implemented in the tested gxbox observer restore module
+for now. This public wrapper provides the stable import path that future
+consumers, including gximagecomputing, should target.
+"""
+
+from pyampp.gxbox.observer_restore import (
+    build_ephemeris_from_pb0r,
+    build_pb0r_metadata_from_ephemeris,
+    normalize_observer_key,
+    resolve_named_observer,
+    resolve_observer_from_metadata,
+    resolve_observer_with_info,
+    resolve_sdo_observer_from_b3d,
+)
+
+__all__ = [
+    "build_ephemeris_from_pb0r",
+    "build_pb0r_metadata_from_ephemeris",
+    "normalize_observer_key",
+    "resolve_named_observer",
+    "resolve_observer_from_metadata",
+    "resolve_observer_with_info",
+    "resolve_sdo_observer_from_b3d",
+]

--- a/pyampp/gxbox/box.py
+++ b/pyampp/gxbox/box.py
@@ -11,6 +11,14 @@ from sunpy.coordinates import (
     Heliocentric,
 )
 from sunpy.map import make_fitswcs_header
+from pyampp.geometry.core import (
+    compute_inscribing_fov_box_from_world,
+    compute_inscribing_fov_from_world,
+    local_cartesian_to_world,
+    observer_fov_box_to_world_corners,
+    project_world_to_observer_hcc,
+    project_world_to_observer_hpc,
+)
 from pyampp.gxbox.observer_restore import resolve_observer_from_metadata, resolve_named_observer, resolve_observer_with_info
 from pyampp.util.config import IDL_HMI_RSUN_M
 try:
@@ -68,13 +76,7 @@ class BoxGeometryMixin:
         if box_frame is None:
             return None
         local = self.model_box_corners_local_mm()
-        zbase = self.grid_zbase_mm()
-        return SkyCoord(
-            x=local[:, 0] * u.Mm,
-            y=local[:, 1] * u.Mm,
-            z=(local[:, 2] + zbase) * u.Mm,
-            frame=box_frame,
-        )
+        return local_cartesian_to_world(local, frame=box_frame, z_base_mm=self.grid_zbase_mm())
 
     def model_box_corners_projected(self, observer=None, obstime=None) -> SkyCoord | None:
         """
@@ -111,11 +113,7 @@ class BoxGeometryMixin:
             obstime = getattr(box_frame, "obstime", None)
         if observer is None:
             return None
-        try:
-            target_frame = Helioprojective(observer=observer, obstime=obstime)
-            return world.transform_to(target_frame)
-        except Exception:
-            return None
+        return project_world_to_observer_hpc(world, observer=observer, obstime=obstime, frame_obs=frame_obs)
 
     def model_box_corners_observer_heliocentric(self, observer=None, obstime=None) -> SkyCoord | None:
         """
@@ -137,10 +135,7 @@ class BoxGeometryMixin:
             obstime = getattr(box_frame, "obstime", None)
         if observer is None:
             return None
-        try:
-            return world.transform_to(Heliocentric(observer=observer, obstime=obstime))
-        except Exception:
-            return None
+        return project_world_to_observer_hcc(world, observer=observer, obstime=obstime, frame_obs=frame_obs)
 
     def model_box_inscribing_fov(self, observer=None, obstime=None, pad_arcsec: float = 0.0) -> dict | None:
         """
@@ -149,32 +144,14 @@ class BoxGeometryMixin:
         The returned rectangle is the smallest axis-aligned HPC rectangle that
         contains the projected 8 red-box corners for the given observer.
         """
-        corners = self.model_box_corners_projected(observer=observer, obstime=obstime)
-        if corners is None:
-            return None
-        try:
-            tx = np.asarray(corners.Tx.to_value(u.arcsec), dtype=float)
-            ty = np.asarray(corners.Ty.to_value(u.arcsec), dtype=float)
-        except Exception:
-            return None
-        if tx.size != 8 or ty.size != 8 or not np.all(np.isfinite(tx)) or not np.all(np.isfinite(ty)):
-            return None
-        pad = max(float(pad_arcsec), 0.0)
-        xmin = float(np.min(tx)) - pad
-        xmax = float(np.max(tx)) + pad
-        ymin = float(np.min(ty)) - pad
-        ymax = float(np.max(ty)) + pad
-        return {
-            "xc_arcsec": 0.5 * (xmin + xmax),
-            "yc_arcsec": 0.5 * (ymin + ymax),
-            "xsize_arcsec": xmax - xmin,
-            "ysize_arcsec": ymax - ymin,
-            "xmin_arcsec": xmin,
-            "xmax_arcsec": xmax,
-            "ymin_arcsec": ymin,
-            "ymax_arcsec": ymax,
-            "corners_hpc": corners,
-        }
+        world = self.model_box_corners_world()
+        return compute_inscribing_fov_from_world(
+            world,
+            observer=observer,
+            obstime=obstime,
+            frame_obs=getattr(self, "_frame_obs", None),
+            pad_arcsec=pad_arcsec,
+        )
 
     def model_box_inscribing_fov_box(
         self,
@@ -191,32 +168,15 @@ class BoxGeometryMixin:
         extent is derived from the red-box corners in the observer-centric
         heliocentric frame, with an optional fractional padding.
         """
-        footprint = self.model_box_inscribing_fov(observer=observer, obstime=obstime, pad_arcsec=pad_xy_arcsec)
-        if footprint is None:
-            return None
-        corners_hcc = self.model_box_corners_observer_heliocentric(observer=observer, obstime=obstime)
-        if corners_hcc is None:
-            return None
-        try:
-            z_vals = np.asarray(corners_hcc.z.to_value(u.Mm), dtype=float)
-        except Exception:
-            return None
-        finite = np.isfinite(z_vals)
-        if not np.any(finite):
-            return None
-        z_vals = z_vals[finite]
-        z_min = float(np.nanmin(z_vals))
-        z_max = float(np.nanmax(z_vals))
-        z_span = max(1e-6, z_max - z_min)
-        z_pad = max(0.0, float(pad_z_frac)) * z_span
-        result = dict(footprint)
-        result.update(
-            {
-                "zmin_mm": z_min - z_pad,
-                "zmax_mm": z_max + z_pad,
-            }
+        world = self.model_box_corners_world()
+        return compute_inscribing_fov_box_from_world(
+            world,
+            observer=observer,
+            obstime=obstime,
+            frame_obs=getattr(self, "_frame_obs", None),
+            pad_xy_arcsec=pad_xy_arcsec,
+            pad_z_frac=pad_z_frac,
         )
-        return result
 
     def fov_box_corners_world(self, fov_box_meta: dict | None = None) -> SkyCoord | None:
         observer_meta = self.b3d.get("observer", {}) if isinstance(getattr(self, "b3d", None), dict) else {}
@@ -263,32 +223,17 @@ class BoxGeometryMixin:
         if observer is None or box_frame is None:
             return None
 
-        try:
-            dsun = float(observer.radius.to_value(u.Mm))
-        except Exception:
-            return None
-
-        frame_hpc = Helioprojective(observer=observer, obstime=obstime)
-        half_w = 0.5 * max(float(xsize), 1e-6)
-        half_h = 0.5 * max(float(ysize), 1e-6)
-        corners = []
-        for z_mm in (float(zmin), float(zmax)):
-            distance_mm = dsun - z_mm
-            if not np.isfinite(distance_mm) or distance_mm <= 0:
-                return None
-            for ty in (float(yc) - half_h, float(yc) + half_h):
-                for tx in (float(xc) - half_w, float(xc) + half_w):
-                    corners.append(
-                        SkyCoord(
-                            Tx=tx * u.arcsec,
-                            Ty=ty * u.arcsec,
-                            distance=distance_mm * u.Mm,
-                            frame=frame_hpc,
-                        ).transform_to(box_frame)
-                    )
-        if len(corners) != 8:
-            return None
-        return SkyCoord(corners)
+        return observer_fov_box_to_world_corners(
+            xc_arcsec=xc,
+            yc_arcsec=yc,
+            xsize_arcsec=xsize,
+            ysize_arcsec=ysize,
+            zmin_mm=zmin,
+            zmax_mm=zmax,
+            observer=observer,
+            obstime=obstime,
+            target_frame=box_frame,
+        )
 
     def fov_box_corners_local_mm(self, fov_box_meta: dict | None = None) -> np.ndarray | None:
         world = self.fov_box_corners_world(fov_box_meta=fov_box_meta)

--- a/pyampp/gxbox/map_box_view.py
+++ b/pyampp/gxbox/map_box_view.py
@@ -42,6 +42,14 @@ from sunpy.coordinates import (
 )
 from sunpy.visualization import colormaps as sunpy_colormaps
 
+from pyampp.geometry import (
+    local_cartesian_to_world,
+    observer_rectangle_to_hpc_corners,
+    project_box_front_face_to_observer_hpc,
+    project_coordinate_edges_to_observer_hpc,
+    project_world_to_observer_hpc,
+    project_world_to_pixel,
+)
 from .box import Box
 from .boxutils import load_sunpy_map_compat, map_from_data_header_compat
 from .observer_restore import (
@@ -2941,16 +2949,20 @@ class MapBoxDisplayWidget(QWidget):
                     # Mirror the legacy GxBox field-line overlay behavior:
                     # convert streamline coords from HCC to observer HPC, project to
                     # map pixels, then render pixel-space LineCollection segments.
-                    coord_hcc = SkyCoord(
-                        x=coord[:, 0] * u.Mm,
-                        y=coord[:, 1] * u.Mm,
-                        z=(coord[:, 2] + self._fieldline_z_base) * u.Mm,
+                    coord_world = local_cartesian_to_world(
+                        coord,
                         frame=frame_hcc,
+                        z_base_mm=self._fieldline_z_base,
                     )
-                    coord_hpc = coord_hcc.transform_to(frame_obs)
-                    xpix, ypix = self._current_map.world_to_pixel(coord_hpc)
-                    x = np.asarray(xpix.value if hasattr(xpix, "value") else xpix, dtype=float)
-                    y = np.asarray(ypix.value if hasattr(ypix, "value") else ypix, dtype=float)
+                    coord_hpc = project_world_to_observer_hpc(
+                        coord_world,
+                        observer=current_observer,
+                        obstime=current_obstime,
+                    )
+                    projected = project_world_to_pixel(coord_hpc, self._current_map)
+                    if projected is None:
+                        continue
+                    x, y = projected
                     magnitude = np.asarray(field["magnitude"], dtype=float)
                     if x.size < 2 or y.size < 2 or magnitude.size < 2:
                         continue
@@ -3924,10 +3936,13 @@ class MapBoxDisplayWidget(QWidget):
                     fov_box.as_observer_metadata(square=bool(self._state.square_fov))
                 )
                 if corners_world is not None and len(corners_world) == 8:
-                    return [
-                        SkyCoord([corners_world[i], corners_world[j]]).transform_to(frame_obs)
-                        for i, j in _BOX_EDGE_INDEX_PAIRS
-                    ]
+                    projected_edges = project_coordinate_edges_to_observer_hpc(
+                        corners_world,
+                        edge_pairs=_BOX_EDGE_INDEX_PAIRS,
+                        frame_obs=frame_obs,
+                    )
+                    if projected_edges is not None:
+                        return projected_edges
 
         fov_like = fov_rect or fov_box
         if fov_like is None:
@@ -3939,22 +3954,23 @@ class MapBoxDisplayWidget(QWidget):
         source_frame = Helioprojective(observer=source_observer, obstime=source_obstime)
         half_w = 0.5 * max(float(fov_like.width_arcsec), 1e-3)
         half_h = 0.5 * max(float(fov_like.height_arcsec), 1e-3)
-        base_corners = [
-            SkyCoord(Tx=(float(fov_like.center_x_arcsec) - half_w) * u.arcsec,
-                     Ty=(float(fov_like.center_y_arcsec) - half_h) * u.arcsec,
-                     frame=source_frame),
-            SkyCoord(Tx=(float(fov_like.center_x_arcsec) + half_w) * u.arcsec,
-                     Ty=(float(fov_like.center_y_arcsec) - half_h) * u.arcsec,
-                     frame=source_frame),
-            SkyCoord(Tx=(float(fov_like.center_x_arcsec) - half_w) * u.arcsec,
-                     Ty=(float(fov_like.center_y_arcsec) + half_h) * u.arcsec,
-                     frame=source_frame),
-            SkyCoord(Tx=(float(fov_like.center_x_arcsec) + half_w) * u.arcsec,
-                     Ty=(float(fov_like.center_y_arcsec) + half_h) * u.arcsec,
-                     frame=source_frame),
-        ]
-        corners = base_corners + [c for c in base_corners]
-        return [SkyCoord([corners[i], corners[j]]).transform_to(frame_obs) for i, j in _BOX_EDGE_INDEX_PAIRS]
+        base_corners = observer_rectangle_to_hpc_corners(
+            xc_arcsec=float(fov_like.center_x_arcsec),
+            yc_arcsec=float(fov_like.center_y_arcsec),
+            xsize_arcsec=2.0 * half_w,
+            ysize_arcsec=2.0 * half_h,
+            observer=source_observer,
+            obstime=source_obstime,
+        )
+        if base_corners is None or len(base_corners) != 4:
+            return []
+        corners = SkyCoord(list(base_corners) + list(base_corners))
+        projected_edges = project_coordinate_edges_to_observer_hpc(
+            corners,
+            edge_pairs=_BOX_EDGE_INDEX_PAIRS,
+            frame_obs=frame_obs,
+        )
+        return projected_edges or []
 
     def _fov_box_projected_face(self, smap) -> SkyCoord | None:
         if self._state is None or self._state.fov_box is None:
@@ -3978,22 +3994,7 @@ class MapBoxDisplayWidget(QWidget):
         )
         if corners_world is None or len(corners_world) != 8:
             return None
-        try:
-            corners_obs = corners_world.transform_to(frame_obs)
-            face_a = np.array([0, 1, 3, 2], dtype=int)
-            face_b = np.array([4, 5, 7, 6], dtype=int)
-
-            def _mean_distance(indices: np.ndarray) -> float:
-                try:
-                    return float(np.nanmean(corners_obs[indices].distance.to_value(u.Mm)))
-                except Exception:
-                    return np.inf
-
-            face = face_a if _mean_distance(face_a) <= _mean_distance(face_b) else face_b
-            ordered = [corners_obs[int(i)] for i in face] + [corners_obs[int(face[0])]]
-            return SkyCoord(ordered)
-        except Exception:
-            return None
+        return project_box_front_face_to_observer_hpc(corners_world, frame_obs=frame_obs)
 
     def _box_bounds_to_fov_selection(self, box, smap) -> DisplayFovSelection:
         bounds = box.bounds_coords.transform_to(

--- a/pyampp/tests/test_geometry_core.py
+++ b/pyampp/tests/test_geometry_core.py
@@ -97,6 +97,15 @@ def test_public_geometry_core_projects_vectorized_polyline_to_pixels() -> None:
     assert np.all(np.isfinite(pixels[1]))
 
 
+def test_local_cartesian_to_world_rejects_nonfinite_rows() -> None:
+    box, _obs_time, _observer, _frame_obs = _make_test_box()
+    local = np.array([[0.0, 0.0, 0.0], [np.nan, 1.0, 2.0]], dtype=float)
+
+    world = local_cartesian_to_world(local, frame=getattr(getattr(box, "_center", None), "frame", None), z_base_mm=0.0)
+
+    assert world is None
+
+
 def test_public_geometry_core_reconstructs_saved_fov_box_corners() -> None:
     box, obs_time, observer, _frame_obs = _make_test_box()
     world = observer_fov_box_to_world_corners(

--- a/pyampp/tests/test_geometry_core.py
+++ b/pyampp/tests/test_geometry_core.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.time import Time
+from sunpy.coordinates import Heliocentric, Helioprojective, get_earth
+from sunpy.map import Map, make_fitswcs_header
+
+from pyampp.geometry import (
+    compute_inscribing_fov_box_from_world,
+    compute_inscribing_fov_from_world,
+    local_cartesian_to_world,
+    observer_fov_box_to_world_corners,
+    observer_rectangle_to_hpc_corners,
+    project_box_front_face_to_observer_hpc,
+    project_coordinate_edges_to_observer_hpc,
+    project_world_to_observer_hpc,
+    project_world_to_pixel,
+)
+from pyampp.gxbox.box import Box
+
+
+def _make_test_box() -> tuple[Box, Time, object, object]:
+    obs_time = Time("2024-05-12T16:00:00")
+    observer = get_earth(obs_time)
+    frame_obs = Helioprojective(observer=observer, obstime=obs_time)
+    box_origin = SkyCoord(Tx=0 * u.arcsec, Ty=0 * u.arcsec, distance=observer.radius, frame=frame_obs)
+    frame_hcc = Heliocentric(observer=observer, obstime=obs_time)
+    box_center = box_origin.transform_to(frame_hcc)
+    box_center = SkyCoord(x=box_center.x, y=box_center.y, z=box_center.z + 20 * u.Mm, frame=box_center.frame)
+    box = Box(frame_obs, box_origin, box_center, np.array([8, 6, 4]) * u.pix, np.array([5.0, 5.0, 10.0]) * u.Mm)
+    return box, obs_time, observer, frame_obs
+
+
+def test_public_geometry_core_matches_box_wrapper_fov_results() -> None:
+    box, _obs_time, _observer, frame_obs = _make_test_box()
+
+    world = box.model_box_corners_world()
+    assert world is not None
+
+    fov_from_box = box.model_box_inscribing_fov()
+    fov_box_from_box = box.model_box_inscribing_fov_box()
+    assert fov_from_box is not None
+    assert fov_box_from_box is not None
+
+    fov_from_core = compute_inscribing_fov_from_world(world, frame_obs=frame_obs)
+    fov_box_from_core = compute_inscribing_fov_box_from_world(world, frame_obs=frame_obs)
+
+    assert fov_from_core is not None
+    assert fov_box_from_core is not None
+    for key in ("xc_arcsec", "yc_arcsec", "xsize_arcsec", "ysize_arcsec"):
+        assert np.isclose(float(fov_from_box[key]), float(fov_from_core[key]))
+        assert np.isclose(float(fov_box_from_box[key]), float(fov_box_from_core[key]))
+    for key in ("zmin_mm", "zmax_mm"):
+        assert np.isclose(float(fov_box_from_box[key]), float(fov_box_from_core[key]))
+
+
+def test_public_geometry_core_projects_vectorized_polyline_to_pixels() -> None:
+    obs_time = Time("2024-05-12T16:00:00")
+    observer = get_earth(obs_time)
+    frame_obs = Helioprojective(observer=observer, obstime=obs_time)
+    origin = SkyCoord(Tx=0 * u.arcsec, Ty=0 * u.arcsec, distance=observer.radius, frame=frame_obs)
+    frame_hcc = Heliocentric(observer=observer, obstime=obs_time)
+    center = origin.transform_to(frame_hcc)
+
+    coords = np.array(
+        [
+            [-10.0, -5.0, 0.0],
+            [-5.0, -2.0, 5.0],
+            [0.0, 0.0, 10.0],
+            [5.0, 3.0, 12.0],
+            [10.0, 6.0, 15.0],
+        ],
+        dtype=float,
+    )
+    world = local_cartesian_to_world(coords, frame=center.frame, z_base_mm=0.0)
+    hpc = project_world_to_observer_hpc(world, observer=observer, obstime=obs_time)
+
+    header = make_fitswcs_header(
+        data=np.zeros((128, 128)),
+        coordinate=SkyCoord(Tx=0 * u.arcsec, Ty=0 * u.arcsec, frame=frame_obs),
+        scale=[2.0, 2.0] * (u.arcsec / u.pix),
+        instrument="TEST",
+        observatory="TEST",
+        wavelength=171 * u.angstrom,
+    )
+    smap = Map(np.zeros((128, 128)), header)
+    pixels = project_world_to_pixel(hpc, smap)
+
+    assert world is not None
+    assert hpc is not None
+    assert pixels is not None
+    assert pixels[0].shape == (5,)
+    assert pixels[1].shape == (5,)
+    assert np.all(np.isfinite(pixels[0]))
+    assert np.all(np.isfinite(pixels[1]))
+
+
+def test_public_geometry_core_reconstructs_saved_fov_box_corners() -> None:
+    box, obs_time, observer, _frame_obs = _make_test_box()
+    world = observer_fov_box_to_world_corners(
+        xc_arcsec=20.0,
+        yc_arcsec=-10.0,
+        xsize_arcsec=40.0,
+        ysize_arcsec=30.0,
+        zmin_mm=-5.0,
+        zmax_mm=15.0,
+        observer=observer,
+        obstime=obs_time,
+        target_frame=getattr(getattr(box, "_center", None), "frame", None),
+    )
+
+    assert world is not None
+    assert len(world) == 8
+
+
+def test_public_geometry_core_projects_box_edges_to_observer_hpc() -> None:
+    box, obs_time, observer, frame_obs = _make_test_box()
+    world = observer_fov_box_to_world_corners(
+        xc_arcsec=20.0,
+        yc_arcsec=-10.0,
+        xsize_arcsec=40.0,
+        ysize_arcsec=30.0,
+        zmin_mm=-5.0,
+        zmax_mm=15.0,
+        observer=observer,
+        obstime=obs_time,
+        target_frame=getattr(getattr(box, "_center", None), "frame", None),
+    )
+
+    edges = project_coordinate_edges_to_observer_hpc(
+        world,
+        edge_pairs=((0, 1), (0, 2), (0, 4), (1, 3), (1, 5), (2, 3), (2, 6), (3, 7), (4, 5), (4, 6), (5, 7), (6, 7)),
+        frame_obs=frame_obs,
+    )
+
+    assert edges is not None
+    assert len(edges) == 12
+    assert all(len(edge) == 2 for edge in edges)
+    assert all(np.all(np.isfinite(edge.Tx.to_value(u.arcsec))) for edge in edges)
+    assert all(np.all(np.isfinite(edge.Ty.to_value(u.arcsec))) for edge in edges)
+
+
+def test_public_geometry_core_projects_front_face_and_rectangle_corners() -> None:
+    box, obs_time, observer, frame_obs = _make_test_box()
+    world = observer_fov_box_to_world_corners(
+        xc_arcsec=20.0,
+        yc_arcsec=-10.0,
+        xsize_arcsec=40.0,
+        ysize_arcsec=30.0,
+        zmin_mm=-5.0,
+        zmax_mm=15.0,
+        observer=observer,
+        obstime=obs_time,
+        target_frame=getattr(getattr(box, "_center", None), "frame", None),
+    )
+    face = project_box_front_face_to_observer_hpc(world, frame_obs=frame_obs)
+    rect = observer_rectangle_to_hpc_corners(
+        xc_arcsec=20.0,
+        yc_arcsec=-10.0,
+        xsize_arcsec=40.0,
+        ysize_arcsec=30.0,
+        observer=observer,
+        obstime=obs_time,
+    )
+
+    assert face is not None
+    assert len(face) == 5
+    assert np.all(np.isfinite(face.Tx.to_value(u.arcsec)))
+    assert np.all(np.isfinite(face.Ty.to_value(u.arcsec)))
+    assert rect is not None
+    assert len(rect) == 4
+    assert np.all(np.isfinite(rect.Tx.to_value(u.arcsec)))
+    assert np.all(np.isfinite(rect.Ty.to_value(u.arcsec)))


### PR DESCRIPTION
## Summary

This PR promotes the existing gxbox geometry kernel into a public, headless `pyampp.geometry` API so downstream code can reuse the same observer-aware geometry logic without depending on viewer internals.

The goal is to make pyAMPP the authoritative owner of the shared Python geometry path while preserving current gxbox behavior through wrapper-based migration rather than a rewrite.

## What changed

- Added a new public geometry package:
  - `pyampp.geometry`
  - `pyampp.geometry.core`
  - `pyampp.geometry.observer`
- Exposed a stable public import surface for:
  - local Cartesian to world transforms
  - world to observer HPC/HCC projection
  - inscribing FOV computation
  - observer-aligned `fov_box` computation
  - saved `fov_box` world-corner reconstruction
  - observer rectangle corner construction
  - projected edge and front-face helpers
  - world-to-pixel projection
- Kept existing gxbox compatibility surfaces in place:
  - `Box`
  - `BoxGeometryMixin`
- Rewired existing gxbox box methods to delegate to the new public core instead of carrying their own inline implementations.
- Migrated remaining generalized 2D viewer projection helpers to the public core:
  - field-line projection path
  - FOV-box projected edge overlay
  - FOV-box projected front-face overlay
- Added focused documentation for the new public geometry API and current migration status.
- Exposed `geometry` from the top-level `pyampp` package.

## Design intent

This PR is intentionally scoped as a promotion and wrapper-based consolidation step.

It does **not** attempt a broad geometry rewrite. Existing gxbox behavior is preserved, while the reusable geometry logic is moved behind a public API that later downstream consumers can import directly.

This is the intended dependency order:

1. stabilize and merge the public geometry API in pyAMPP
2. update gximagecomputing to consume the merged API
3. move later downstream consumers such as pyCHMP onto the same shared path

## Public API added

The new public surface currently includes:

- `local_cartesian_to_world`
- `project_world_to_observer_hpc`
- `project_world_to_observer_hcc`
- `compute_inscribing_fov_from_hpc`
- `compute_inscribing_fov_from_world`
- `compute_inscribing_fov_box_from_world`
- `observer_fov_box_to_world_corners`
- `observer_rectangle_to_hpc_corners`
- `project_coordinate_edges_to_observer_hpc`
- `project_box_front_face_to_observer_hpc`
- `project_world_to_pixel`

Observer-resolution helpers are also re-exported through `pyampp.geometry.observer`.

## Documentation

Added documentation for:

- public API intent
- function-level contract summary
- wrapper-based migration strategy
- what is already migrated vs. what remains intentionally deferred
- minimal usage examples

## Validation

Focused validation completed with:

```bash
python -m pytest -o addopts='' pyampp/tests/test_geometry_core.py -q
```

Result:

- `5 passed`

Note:
The `-o addopts=''` override was needed because the local test environment does not currently provide the doctest-related pytest plugin expected by the repo configuration.

## Reviewer guidance

Please review this PR for:

- behavioral parity with current gxbox geometry behavior
- API suitability for downstream imports
- scope discipline: promotion and reuse, not rewrite
- whether the public names exported from `pyampp.geometry` are acceptable as the long-term downstream contract

## Follow-up work

Not part of this PR:

- switching gximagecomputing to import `pyampp.geometry`
- promoting pyCHMP onto the same shared geometry path
- deeper refactoring of observer helper implementation internals once the public import contract is settled
