### PR TITLE
feat(io): v1.0.2 shared FITS refmap import for gx-fov2box and viewers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,35 @@ Unreleased
 - Added redundant derived ``observer/pb0r`` metadata alongside canonical
   ``observer/ephemeris`` for SSW-style ``B0 / L0 / Rsun`` interoperability.
 
+1.0.2
+-----
+
+Release focus:
+
+- shared FITS reference-map import for ``gx-fov2box`` and viewer tools,
+- external AIA/EOVSA context maps via ``--refmaps-path``,
+- DRMS downloader and runtime stage-normalization fixes.
+
+Highlights:
+
+- Added ``pyampp.io.refmaps`` for FITS discovery, model-time alignment from
+  ``base/index``, and HDF5 ``refmaps/`` embedding (AIA, EOVSA, and generic
+  user-supplied maps).
+- Wired ``--refmaps-path`` through ``gx-fov2box``, the GUI (directory picker),
+  and ``gxbox-view2d`` (file or directory for interactive selector context).
+- JSOC cache scans import only recognized context products (``generic=False``);
+  explicit ``--refmaps-path`` directories use generic fallback ids.
+- ``Vert_current`` reference maps now use ``build_refmap_payload_for_model`` for
+  WCS serialization and model-FOV alignment like other Earth line-of-sight maps.
+- Fixed DRMS downloads to retain returned AIA context FITS paths when the final
+  cache verification pass does not list them yet.
+- Fixed runtime stage normalization to preserve internal 3D axis order while
+  still injecting ``geometry_contract`` metadata.
+
+Packaging/versioning:
+
+- Bumped package version to ``1.0.2`` in packaging metadata.
+
 1.0.1
 -----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@
 # -- Project information -----------------------------------------------------
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.1"
+release = "1.0.2"
 
 project = "pyAMPP"
 copyright = "2022, suncast-org"

--- a/docs/gui_workflow.rst
+++ b/docs/gui_workflow.rst
@@ -131,8 +131,8 @@ Context-map toggles:
 
 - EUV checkbox -> ``--euv``
 - UV checkbox -> ``--uv``
-- Reference Map Path -> ``--refmaps-path``. The path may point to a FITS file
-  or a directory of FITS files. These maps are imported through the shared
+- Reference Map Path -> ``--refmaps-path``. The GUI expects a directory of FITS
+  reference maps. These maps are imported through the shared
   ``pyampp.io.refmaps`` policy and are available to ``gxbox-view2d`` after
   download-stage stops.
 

--- a/docs/gui_workflow.rst
+++ b/docs/gui_workflow.rst
@@ -16,10 +16,11 @@ The GUI is a thin command constructor for reproducible CLI runs. It:
 Data Repositories
 -----------------
 
-The GUI has three path fields:
+The GUI has four repository/path fields:
 
 - ``SDO Data Dir`` (mapped to ``--data-dir``)
 - ``GX Models Dir`` (mapped to ``--gxmodel-dir``)
+- ``Reference Map Path`` (mapped to ``--refmaps-path`` when set)
 - ``Entry Box`` (mapped to ``--entry-box`` when set)
 
 Current behavior:
@@ -130,6 +131,10 @@ Context-map toggles:
 
 - EUV checkbox -> ``--euv``
 - UV checkbox -> ``--uv``
+- Reference Map Path -> ``--refmaps-path``. The path may point to a FITS file
+  or a directory of FITS files. These maps are imported through the shared
+  ``pyampp.io.refmaps`` policy and are available to ``gxbox-view2d`` after
+  download-stage stops.
 
 Command Display and Execution
 -----------------------------

--- a/docs/gx_fov2box_usage.rst
+++ b/docs/gx_fov2box_usage.rst
@@ -23,8 +23,8 @@ Typical repository paths:
 
 - ``--data-dir`` for downloaded SDO source data
 - ``--gxmodel-dir`` for generated model stages
-- optional ``--refmaps-path`` for additional FITS reference-map files or
-  directories to embed in the saved box
+- optional ``--refmaps-path`` for a directory of external FITS reference maps to
+  embed in the saved box
 
 Projection choice:
 
@@ -247,8 +247,8 @@ Useful flags:
 - ``--force-download`` to bypass cache reuse
 - ``--euv`` to include AIA EUV context maps
 - ``--uv`` to include AIA UV context maps
-- ``--refmaps-path PATH`` to include additional FITS reference maps from a file
-  or directory. This option may be passed more than once.
+- ``--refmaps-path PATH`` to include additional FITS reference maps from a
+  directory. This option may be passed more than once.
 
 Reference-map import policy:
 

--- a/docs/gx_fov2box_usage.rst
+++ b/docs/gx_fov2box_usage.rst
@@ -23,6 +23,8 @@ Typical repository paths:
 
 - ``--data-dir`` for downloaded SDO source data
 - ``--gxmodel-dir`` for generated model stages
+- optional ``--refmaps-path`` for additional FITS reference-map files or
+  directories to embed in the saved box
 
 Projection choice:
 
@@ -245,6 +247,24 @@ Useful flags:
 - ``--force-download`` to bypass cache reuse
 - ``--euv`` to include AIA EUV context maps
 - ``--uv`` to include AIA UV context maps
+- ``--refmaps-path PATH`` to include additional FITS reference maps from a file
+  or directory. This option may be passed more than once.
+
+Reference-map import policy:
+
+- ``gx-fov2box`` uses the shared ``pyampp.io.refmaps`` API to identify,
+  align, and embed FITS reference maps.
+- Known AIA and EOVSA FITS files found in the dated ``--data-dir`` cache are
+  eligible reference maps after the download stage. Unknown FITS files in the
+  JSOC cache are ignored so HMI source products are not imported accidentally.
+- FITS files supplied with ``--refmaps-path`` are user-requested and are
+  imported with generic fallback ids when they are not recognized as known
+  instrument products.
+- The model time used for reference-map alignment is read from ``base/index``,
+  matching the model geometry contract.
+- Earth/SDO line-of-sight maps are aligned to the model time and reprojected
+  to the model reference-map footprint. Non-Earth maps are stored in their
+  native WCS footprint.
 
 The download stage can be exercised by itself with:
 
@@ -259,9 +279,15 @@ The download stage can be exercised by itself with:
      --dx-km 1400 \
      --data-dir /path/to/jsoc_cache \
      --gxmodel-dir /path/to/gx_models \
+     --refmaps-path /path/to/external/refmaps \
      --euv \
      --uv \
      --stop-after dl
+
+When the download-stage box is opened in ``gxbox-view2d``, filesystem AIA maps
+from ``--data-dir`` and recognized maps from ``--refmaps-path`` are exposed in
+the context-map menu to support interactive FOV selection before the magnetic
+model is built.
 
 Entry-Box Workflow Flags
 ------------------------

--- a/docs/model_hdf5_format.rst
+++ b/docs/model_hdf5_format.rst
@@ -142,6 +142,17 @@ Optional context maps, each in its own subgroup:
 - ``refmaps/<map_id>/data``
 - ``refmaps/<map_id>/wcs_header``
 
+External FITS reference maps imported by ``gx-fov2box`` or
+``pyampp.io.refmaps`` are stored in this same layout. Each imported map group
+may also carry:
+
+- ``refmaps/<map_id>.attrs["order_index"]`` for stable viewer ordering
+- ``refmaps/<map_id>.attrs["source_path"]`` for source-file provenance
+
+For generated boxes, reference-map alignment uses the model time inferred from
+``base/index``. Earth/SDO line-of-sight maps are reprojected to the model
+reference-map footprint; non-Earth maps keep their native WCS footprint.
+
 ``grid``
 ~~~~~~~~
 

--- a/docs/model_io.rst
+++ b/docs/model_io.rst
@@ -34,7 +34,7 @@ Use these functions from ``pyampp.io``:
 - ``export_thin_model(source_model, output_h5=None, strict=False)``
 - ``add_fits_refmaps_to_h5(h5_path, fits_paths, ...)``
 - ``add_fits_refmaps_from_dir_to_h5(h5_path, fits_dir, ...)``
-- ``build_fits_refmaps_for_model(paths, model_box, ...)``
+- ``build_fits_refmaps_for_model(paths, model_obstime=..., target_fov=..., ...)``
 - ``discover_fits_refmap_map_ids(paths, ...)``
 
 The package-level import surface is:

--- a/docs/model_io.rst
+++ b/docs/model_io.rst
@@ -32,6 +32,10 @@ Use these functions from ``pyampp.io``:
 - ``load_model_metadata(path, strict=False)``
 - ``save_thin_model(thin_model, path)``
 - ``export_thin_model(source_model, output_h5=None, strict=False)``
+- ``add_fits_refmaps_to_h5(h5_path, fits_paths, ...)``
+- ``add_fits_refmaps_from_dir_to_h5(h5_path, fits_dir, ...)``
+- ``build_fits_refmaps_for_model(paths, model_box, ...)``
+- ``discover_fits_refmap_map_ids(paths, ...)``
 
 The package-level import surface is:
 
@@ -83,6 +87,42 @@ Recommended for application and downstream code:
 
 This separation removes duplicated fallback logic in downstream consumers and
 keeps one authoritative contract-completion path in pyAMPP.
+
+Reference-Map Import API
+------------------------
+
+External FITS context maps should be imported through ``pyampp.io.refmaps``.
+This keeps instrument identification, model-time alignment, and HDF5 layout in
+one public API used by both ``gx-fov2box`` and the viewer tools.
+
+Typical in-place HDF5 import:
+
+.. code-block:: python
+
+   from pyampp.io import add_fits_refmaps_from_dir_to_h5
+
+   added = add_fits_refmaps_from_dir_to_h5(
+       "/path/to/model.h5",
+       "/path/to/refmap_dir",
+       overwrite=True,
+   )
+
+Policy:
+
+- AIA maps are identified from FITS telescope/instrument metadata plus
+  ``WAVELNTH`` and are stored as ``AIA_<wavelength>``.
+- EOVSA maps are identified from EOVSA telescope/instrument metadata plus
+  ``CRVAL3``/``CUNIT3='Hz'`` and are stored as frequency-labelled maps such as
+  ``EOVSA_f1.418GHz``.
+- Known-map scans of the JSOC cache use ``generic=False`` so unrelated HMI
+  source products are not imported as context maps.
+- Explicit user paths use ``generic=True`` by default, so unknown FITS files
+  receive sanitized filename-based ids.
+- The model time is inferred from ``base/index`` via
+  ``model_obstime_from_base_index``.
+- Earth/SDO line-of-sight maps are time-aligned and reprojected to the selected
+  model reference-map footprint. Non-Earth maps are stored with their native
+  WCS footprint.
 
 Runtime Enforcement Policy
 --------------------------

--- a/docs/viewers.rst
+++ b/docs/viewers.rst
@@ -59,10 +59,11 @@ Additional filesystem reference-map paths:
 
 .. code-block:: bash
 
-   gxbox-view2d /path/to/model.h5 --ref-map-path /path/to/refmaps
+   gxbox-view2d /path/to/model.h5 --refmaps-path /path/to/refmaps
 
-``--ref-map-path`` may be passed more than once. It accepts a FITS file or a
-directory of FITS files. The viewer uses the shared ``pyampp.io.refmaps``
+``--refmaps-path`` may be passed more than once. It accepts a FITS file or a
+directory of FITS files (unlike ``gx-fov2box``, which expects directories for
+embedding). The viewer uses the shared ``pyampp.io.refmaps``
 discovery policy, so recognized AIA maps appear with their wavelength labels
 and EOVSA maps appear with frequency labels such as ``EOVSA_f1.418GHz``.
 

--- a/docs/viewers.rst
+++ b/docs/viewers.rst
@@ -62,9 +62,10 @@ Additional filesystem reference-map paths:
    gxbox-view2d /path/to/model.h5 --refmaps-path /path/to/refmaps
 
 ``--refmaps-path`` may be passed more than once. It accepts a FITS file or a
-directory of FITS files (unlike ``gx-fov2box``, which expects directories for
-embedding). The viewer uses the shared ``pyampp.io.refmaps``
-discovery policy, so recognized AIA maps appear with their wavelength labels
+directory of FITS files. ``gx-fov2box`` and the GUI are intended for
+**directories** of external FITS maps; ``gxbox-view2d`` also accepts a single
+FITS file for interactive context. The shared ``pyampp.io.refmaps`` discovery
+policy applies here, so recognized AIA maps appear with their wavelength labels
 and EOVSA maps appear with frequency labels such as ``EOVSA_f1.418GHz``.
 
 gxrefmap-view

--- a/docs/viewers.rst
+++ b/docs/viewers.rst
@@ -35,6 +35,9 @@ gxbox-view2d
 Behavior:
 
 - loads geometry, stage metadata, and available embedded/base/refmap context from the selected box
+- when a box contains ``metadata/execute`` paths, discovers matching filesystem
+  context maps from ``--data-dir`` and additional FITS maps from
+  ``--refmaps-path``
 - persists updated observer/FOV metadata back to ``.h5`` boxes when the dialog is accepted
 - supports built-in, manual custom, and uploaded-reference observer workflows in the observer panel
 - exposes ``MODEL-DATE`` separately from the true observer ``OBS-DATE`` when the observer record comes from an external reference
@@ -51,6 +54,17 @@ Optional file picker mode:
 .. code-block:: bash
 
    gxbox-view2d --pick
+
+Additional filesystem reference-map paths:
+
+.. code-block:: bash
+
+   gxbox-view2d /path/to/model.h5 --ref-map-path /path/to/refmaps
+
+``--ref-map-path`` may be passed more than once. It accepts a FITS file or a
+directory of FITS files. The viewer uses the shared ``pyampp.io.refmaps``
+discovery policy, so recognized AIA maps appear with their wavelength labels
+and EOVSA maps appear with frequency labels such as ``EOVSA_f1.418GHz``.
 
 gxrefmap-view
 -------------

--- a/pyampp/_version.py
+++ b/pyampp/_version.py
@@ -1,3 +1,3 @@
 """Canonical package version."""
 
-version = "1.0.1"
+version = "1.0.2"

--- a/pyampp/data/downloader.py
+++ b/pyampp/data/downloader.py
@@ -308,7 +308,11 @@ class SDOImageDownloader:
                 self._drms_throttle_seen = False
                 _run_jobs(retry_jobs, 1, "AIA retry")
 
-        return self._check_files_exist(self.path, returnfilelist=True)
+        verified_files = self._check_files_exist(self.path, returnfilelist=True)
+        for key, path in files.items():
+            if path and not verified_files.get(key):
+                verified_files[key] = path
+        return verified_files
 
     def _handle_euv(self, all_files):
         if self.force_download:

--- a/pyampp/gxbox/box_view2d.py
+++ b/pyampp/gxbox/box_view2d.py
@@ -2960,7 +2960,6 @@ class MapBoxDisplayWidget(QWidget):
         if context_key.startswith(_EOVSA_REFMAP_PREFIX):
             return True
         return context_key in _BOTTOM_OVERLAY_CONTEXT_KEYS
-        self._set_runtime_status("Cleared over-plotted field lines.")
 
     def plot_fieldlines(self, streamlines, z_base=0.0) -> None:
         self._fieldline_streamlines = list(streamlines or [])

--- a/pyampp/gxbox/box_view2d.py
+++ b/pyampp/gxbox/box_view2d.py
@@ -97,6 +97,7 @@ _CHROMO_MASK_KEYS = {"chromo_mask"}
 _AIA_REFERENCE_IDS = ("171", "193", "211", "304", "335", "1600", "1700", "131", "94")
 _HMI_VECTOR_DISPLAY_KEYS = {"field", "inclination", "azimuth", "disambig"}
 _AIA_COLOR_KEYS = {"94", "131", "1600", "1700", "171", "193", "211", "304", "335"}
+_EOVSA_REFMAP_PREFIX = "EOVSA_"
 _BOTTOM_OVERLAY_CONTEXT_KEYS = _AIA_COLOR_KEYS | _HMI_VECTOR_DISPLAY_KEYS
 _EMBEDDED_REFMAP_FLAG = "PYEMBED"
 _BOX_EDGE_INDEX_PAIRS = (
@@ -1039,7 +1040,7 @@ class MapBoxDisplayWidget(QWidget):
         self._state.selected_context_id = map_id
         self._refresh_status_text()
         self._refresh_map_info()
-        self._refresh_plot(preserve_current_view=self._should_preserve_pixel_view())
+        self._refresh_plot(preserve_current_view=False)
 
     def set_bottom_map_id(self, map_id: Optional[str]) -> None:
         if self._state is None:
@@ -2274,7 +2275,7 @@ class MapBoxDisplayWidget(QWidget):
             return "Vert_current"
         if key.isdigit():
             return f"AIA_{key}"
-        return None
+        return key
 
     def _load_embedded_refmap(self, ref_key: str, purpose: str = "context"):
         if self._state is None:
@@ -2686,6 +2687,12 @@ class MapBoxDisplayWidget(QWidget):
                 if hi > 0:
                     smap.plot_settings["cmap"] = "RdBu_r"
                     smap.plot_settings["norm"] = mcolors.TwoSlopeNorm(vmin=-hi, vcenter=0.0, vmax=hi)
+            elif str(map_key).startswith(_EOVSA_REFMAP_PREFIX):
+                lo = float(np.nanpercentile(vals, 0.5))
+                hi = float(np.nanpercentile(vals, 99.5))
+                if np.isfinite(lo) and np.isfinite(hi) and hi > lo:
+                    smap.plot_settings["cmap"] = "hot"
+                    smap.plot_settings["norm"] = mcolors.Normalize(vmin=lo, vmax=hi)
             elif map_key in _CHROMO_MASK_KEYS:
                 cmap = mcolors.ListedColormap([
                     "#000000", "#1f77b4", "#ff7f0e", "#2ca02c",
@@ -2950,6 +2957,8 @@ class MapBoxDisplayWidget(QWidget):
             return False
         # Bottom overlay is useful for image-like context maps, but it obscures
         # signed diagnostic maps such as Vert_current almost completely.
+        if context_key.startswith(_EOVSA_REFMAP_PREFIX):
+            return True
         return context_key in _BOTTOM_OVERLAY_CONTEXT_KEYS
         self._set_runtime_status("Cleared over-plotted field lines.")
 

--- a/pyampp/gxbox/gx_fov2box.py
+++ b/pyampp/gxbox/gx_fov2box.py
@@ -48,6 +48,12 @@ from pyampp.gxbox.boxutils import (
     remap_vertical_current_inputs,
 )
 from pyampp.io import load_model
+from pyampp.io.refmaps import (
+    build_fits_refmaps_for_model,
+    build_refmap_payload_for_model,
+    discover_fits_refmap_map_ids,
+    model_obstime_from_base_index,
+)
 from pyampp.io.model import _normalize_loaded_model_dict
 from pyampp.gxbox.gx_box2id import gx_box2id
 from pyampp.gxbox.observer_restore import (
@@ -312,6 +318,7 @@ class Fov2BoxConfig:
     info: bool
     reproject_algorithm: str
     reproject_scan: Optional[str]
+    refmaps_path: Optional[Tuple[str, ...]] = None
 
 
 @dataclass
@@ -983,10 +990,15 @@ def _prepare_observation_state(
     base_group = run_logged_step("Building base-layer products", _build_base_products)
 
     refmaps: Dict[str, Any] = {}
+    refmap_model_time = model_obstime_from_base_index({"base": base_group}) or obs_time.isot
 
     def add_refmap(ref_id: str, smap: Map) -> None:
-        smap = submap_with_fov(smap)
-        refmaps[ref_id] = {"data": smap.data, "wcs_header": _refmap_wcs_header(smap)}
+        refmaps[ref_id] = build_refmap_payload_for_model(
+            smap,
+            model_obstime=refmap_model_time,
+            target_fov=(fov_coords[0], fov_coords[1]),
+            reproject_algorithm=cfg.reproject_algorithm,
+        )
 
     def _collect_refmaps():
         hmi_t0 = time_mod.perf_counter()
@@ -1032,6 +1044,45 @@ def _prepare_observation_state(
             add_refmap(key, maps[key])
             elapsed = time_mod.perf_counter() - aia_t0
             print(f"AIA references: {idx}/{total_aia} ({pb}) in {elapsed:.2f}s")
+        cache_dir = data_dir_path / obs_time.datetime.strftime("%Y-%m-%d")
+        cache_t0 = time_mod.perf_counter()
+        cache_map_ids = {
+            path: map_id
+            for path, map_id in discover_fits_refmap_map_ids([cache_dir], generic=False).items()
+            if map_id not in refmaps
+        }
+        if cache_map_ids:
+            missing_cache_refmaps = build_fits_refmaps_for_model(
+                list(cache_map_ids.keys()),
+                model_obstime=refmap_model_time,
+                target_fov=(fov_coords[0], fov_coords[1]),
+                reproject_algorithm=cfg.reproject_algorithm,
+                map_ids=cache_map_ids,
+                generic=False,
+            )
+            for key, payload in missing_cache_refmaps.items():
+                refmaps[key] = payload
+            print(
+                "Cached context references: "
+                f"{len(missing_cache_refmaps)} from {cache_dir} "
+                f"in {time_mod.perf_counter() - cache_t0:.2f}s"
+            )
+        if cfg.refmaps_path:
+            external_t0 = time_mod.perf_counter()
+            external_refmaps = build_fits_refmaps_for_model(
+                cfg.refmaps_path,
+                model_obstime=refmap_model_time,
+                target_fov=(fov_coords[0], fov_coords[1]),
+                reproject_algorithm=cfg.reproject_algorithm,
+                generic=True,
+            )
+            for key, payload in external_refmaps.items():
+                refmaps[key] = payload
+            print(
+                "External references: "
+                f"{len(external_refmaps)} from {len(cfg.refmaps_path)} path(s) "
+                f"in {time_mod.perf_counter() - external_t0:.2f}s"
+            )
         return local_vert_current_error
 
     vert_current_error = run_logged_step("Collecting reference maps and derived products", _collect_refmaps)
@@ -1308,13 +1359,18 @@ def _normalize_runtime_stage_box_for_pipeline(
         working_box,
         source_axis_order_3d=source_axis_order_3d,
     )
-    return _normalize_loaded_model_dict(
+    normalized_model = _normalize_loaded_model_dict(
         normalized_h5_box,
         source_path=Path(f"{metadata['id']}.h5"),
         source_kind="h5",
         strict=False,
         stored_contract=None,
     )
+    normalized_metadata = normalized_model.get("metadata")
+    if isinstance(normalized_metadata, dict) and "geometry_contract" in normalized_metadata:
+        metadata["geometry_contract"] = normalized_metadata["geometry_contract"]
+        working_box["metadata"] = metadata
+    return working_box
 
 
 def _compute_pot_stage_box(
@@ -2326,6 +2382,8 @@ def _build_execute_cmd(cfg: Fov2BoxConfig) -> str:
         cmd.append("--rebuild-from-none")
     if cfg.reproject_algorithm != "adaptive":
         cmd += ["--reproject-algorithm", cfg.reproject_algorithm]
+    for path in cfg.refmaps_path or ():
+        cmd += ["--refmaps-path", path]
     return shlex.join(cmd)
 
 
@@ -3129,6 +3187,12 @@ def main(
         "--reproject-scan",
         help="Batch-run OBS->NONE once per reprojection algorithm. Use 'all' or a comma-separated list such as 'adaptive,exact,interpolation'. Each run writes to a gxmodel-dir/reproject_<algorithm> subdirectory.",
     ),
+    refmaps_path: Optional[List[str]] = typer.Option(
+        None,
+        "--refmaps-path",
+        "--refmap-path",
+        help="External FITS file or directory of FITS reference maps to add to model refmaps. May be repeated.",
+    ),
 ) -> None:
     cfg = Fov2BoxConfig(
         time=time,
@@ -3182,6 +3246,7 @@ def main(
         info=info,
         reproject_algorithm=reproject_algorithm,
         reproject_scan=reproject_scan,
+        refmaps_path=tuple(refmaps_path or ()),
     )
 
     cfg.download_backend = str(cfg.download_backend or "drms").strip().lower()

--- a/pyampp/gxbox/gx_fov2box.py
+++ b/pyampp/gxbox/gx_fov2box.py
@@ -1012,7 +1012,7 @@ def _prepare_observation_state(
             vc_bx_local, vc_by_local, vc_bz_local = remap_vertical_current_inputs(
                 map_bx, map_by, map_bz
             )
-            vc_header_local = _refmap_wcs_header(vc_bx_local)
+            vc_header_local = vc_bx_local.wcs.to_header().tostring(sep="\n", endcard=True)
             rsun_arcsec_local = vc_bx_local.rsun_obs.to_value(u.arcsec)
             crpix1_local, crpix2_local = vc_bx_local.wcs.wcs.crpix
             cdelt1_local = vc_bx_local.scale.axis1.to_value(u.arcsec / u.pix)
@@ -1028,7 +1028,13 @@ def _prepare_observation_state(
                 cdelt1_arcsec=cdelt1_local,
                 cdelt2_arcsec=cdelt2_local,
             )
-            refmaps["Vert_current"] = {"data": jz_local, "wcs_header": vc_header_local}
+            jz_map = map_from_data_header_compat(jz_local, vc_bx_local.wcs.to_header())
+            refmaps["Vert_current"] = build_refmap_payload_for_model(
+                jz_map,
+                model_obstime=refmap_model_time,
+                target_fov=(fov_coords[0], fov_coords[1]),
+                reproject_algorithm=cfg.reproject_algorithm,
+            )
 
         try:
             run_logged_step("Vertical current", _compute_vert_current)
@@ -2663,41 +2669,6 @@ def _build_index_header(
     return header.tostring(sep="\n", endcard=True)
 
 
-def _refmap_wcs_header(smap: Map) -> str:
-    """
-    Persist enough FITS-WCS metadata to preserve the map timestamp and basic
-    solar observer context across HDF5 save/load cycles.
-    """
-    header = smap.wcs.to_header()
-    try:
-        date_obs = Time(smap.date).isot if getattr(smap, "date", None) is not None else None
-        if date_obs:
-            header["DATE-OBS"] = date_obs
-            header["DATE_OBS"] = date_obs
-    except Exception:
-        pass
-    try:
-        if getattr(smap, "rsun_obs", None) is not None:
-            header["RSUN_OBS"] = float(u.Quantity(smap.rsun_obs).to_value(u.arcsec))
-    except Exception:
-        pass
-    try:
-        if getattr(smap, "rsun_meters", None) is not None:
-            header["RSUN_REF"] = float(u.Quantity(smap.rsun_meters).to_value(u.m))
-    except Exception:
-        pass
-    try:
-        obs = getattr(smap, "observer_coordinate", None)
-        obs_time = getattr(smap, "date", None)
-        if obs is not None and obs_time is not None:
-            obs_hgs = obs.transform_to(HeliographicStonyhurst(obstime=obs_time))
-            header["HGLN_OBS"] = float(obs_hgs.lon.to_value(u.deg))
-            header["HGLT_OBS"] = float(obs_hgs.lat.to_value(u.deg))
-    except Exception:
-        pass
-    return header.tostring(sep="\n", endcard=True)
-
-
 def _print_info(cfg: Fov2BoxConfig) -> None:
     resolved_reduce_passed = cfg.reduce_passed if cfg.reduce_passed is not None else (0 if cfg.center_vox else 1)
     resolved_chromo_level = (1000.0 / float(cfg.dx_km)) if cfg.dx_km else 1.0
@@ -3191,7 +3162,7 @@ def main(
         None,
         "--refmaps-path",
         "--refmap-path",
-        help="External FITS file or directory of FITS reference maps to add to model refmaps. May be repeated.",
+        help="Directory of external FITS reference maps to add to model refmaps. May be repeated.",
     ),
 ) -> None:
     cfg = Fov2BoxConfig(

--- a/pyampp/gxbox/gxampp.py
+++ b/pyampp/gxbox/gxampp.py
@@ -521,7 +521,7 @@ class PyAmppGUI(QMainWindow):
         self.refmaps_path_edit = QLineEdit()
         self.refmaps_path_edit.setText(self._settings.value("paths/refmaps_path", "", type=str))
         self.refmaps_path_edit.setMinimumWidth(520)
-        self.refmaps_path_edit.setToolTip("Optional FITS file or directory of external reference maps")
+        self.refmaps_path_edit.setToolTip("Optional directory of external FITS reference maps")
         self.refmaps_path_edit.returnPressed.connect(self.update_refmaps_path)
         self.refmaps_path_edit.textChanged.connect(self._persist_refmaps_path)
         self.refmaps_browse_button = QPushButton()

--- a/pyampp/gxbox/gxampp.py
+++ b/pyampp/gxbox/gxampp.py
@@ -23,6 +23,7 @@ from pyampp.gxbox.gx_fov2box import (
     _entry_stage_from_loaded,
     _extract_execute_paths,
 )
+from pyampp.gxbox.gxbox_selector_view import _discover_external_ref_map_files, _discover_filesystem_maps
 from pyampp.gxbox.fov_selector_gui import run_fov_box_selector
 from pyampp.gxbox.selector_api import (
     BoxGeometrySelection,
@@ -31,7 +32,6 @@ from pyampp.gxbox.selector_api import (
     SelectorDialogResult,
     SelectorSessionInput,
 )
-from pyampp.data.downloader import SDOImageDownloader
 from pyampp.util.idl_execute_to_gxfov2box import _parse_idl_call, _build_gx_fov2box_command
 from astropy.coordinates import SkyCoord
 import astropy.units as u
@@ -402,6 +402,7 @@ class PyAmppGUI(QMainWindow):
             self._settings.setValue("session/use_cached_downloads", self._use_cached_downloads())
             self._settings.setValue("session/entry_mode", self._get_jump_action())
             self._settings.setValue("session/entry_box_path", self.external_box_edit.text().strip())
+            self._settings.setValue("paths/refmaps_path", self.refmaps_path_edit.text().strip())
             self._settings.setValue("session/entry_is_template_only", self._entry_is_template_only)
 
             bool_widgets = {
@@ -473,6 +474,9 @@ class PyAmppGUI(QMainWindow):
             layout.setColumnStretch(0, 0)
             layout.setColumnStretch(1, 1)
             layout.setColumnStretch(2, 0)
+            spacer = layout.itemAtPosition(3, 2)
+            if spacer is not None and spacer.widget() is None:
+                layout.removeItem(spacer)
         self.sdo_data_edit.setText(self._settings.value("paths/data_dir", DOWNLOAD_DIR, type=str))
         self.sdo_data_edit.setMinimumWidth(520)
         self.sdo_data_edit.returnPressed.connect(self.update_sdo_data_dir)
@@ -504,6 +508,33 @@ class PyAmppGUI(QMainWindow):
         self.external_browse_button.setIcon(self.style().standardIcon(QStyle.SP_DirOpenIcon))
         self.external_browse_button.setToolTip("Select entry model file (.h5/.sav)")
         self.external_browse_button.setFixedWidth(28)
+        if layout is not None:
+            layout.addWidget(self.label_external_box, 3, 0)
+            layout.addWidget(self.external_box_edit, 3, 1)
+            layout.addWidget(self.external_browse_button, 3, 2)
+
+        if layout is not None:
+            layout.addWidget(self.label_jsoc_notify_email, 4, 0)
+            layout.addWidget(self.jsoc_notify_email_edit, 4, 1)
+
+        self.refmaps_path_label = QLabel("Reference Map Path:")
+        self.refmaps_path_edit = QLineEdit()
+        self.refmaps_path_edit.setText(self._settings.value("paths/refmaps_path", "", type=str))
+        self.refmaps_path_edit.setMinimumWidth(520)
+        self.refmaps_path_edit.setToolTip("Optional FITS file or directory of external reference maps")
+        self.refmaps_path_edit.returnPressed.connect(self.update_refmaps_path)
+        self.refmaps_path_edit.textChanged.connect(self._persist_refmaps_path)
+        self.refmaps_browse_button = QPushButton()
+        self.refmaps_browse_button.clicked.connect(self.open_refmaps_path_dialog)
+        self.refmaps_browse_button.setText("")
+        self.refmaps_browse_button.setIcon(self.style().standardIcon(QStyle.SP_DirOpenIcon))
+        self.refmaps_browse_button.setToolTip("Select external reference-map FITS directory")
+        self.refmaps_browse_button.setFixedWidth(28)
+        if layout is not None:
+            layout.addWidget(self.refmaps_path_label, 2, 0)
+            layout.addWidget(self.refmaps_path_edit, 2, 1)
+            layout.addWidget(self.refmaps_browse_button, 2, 2)
+
         self.entry_stage_label = QLabel("Detected Entry Type:")
         self.entry_stage_edit = QLineEdit("N/A")
         self.entry_stage_edit.setReadOnly(True)
@@ -529,8 +560,8 @@ class PyAmppGUI(QMainWindow):
         mode_layout.addWidget(self.modify_radio)
         mode_layout.addStretch()
         if layout is not None:
-            layout.addWidget(self.entry_stage_label, 4, 0)
-            layout.addWidget(self.entry_mode_widget, 4, 1, 1, 2)
+            layout.addWidget(self.entry_stage_label, 5, 0)
+            layout.addWidget(self.entry_mode_widget, 5, 1, 1, 2)
 
     def update_sdo_data_dir(self):
         """
@@ -555,6 +586,13 @@ class PyAmppGUI(QMainWindow):
 
     def _persist_gxmodel_dir(self, text):
         self._settings.setValue("paths/gxmodel_dir", (text or "").strip())
+
+    def update_refmaps_path(self):
+        self._persist_refmaps_path(self.refmaps_path_edit.text())
+        self.update_command_display()
+
+    def _persist_refmaps_path(self, text):
+        self._settings.setValue("paths/refmaps_path", (text or "").strip())
 
     def update_jsoc_notify_email(self):
         """
@@ -756,6 +794,8 @@ class PyAmppGUI(QMainWindow):
             "--pad-frac": 1,
             "--data-dir": 1,
             "--gxmodel-dir": 1,
+            "--refmaps-path": 1,
+            "--refmap-path": 1,
         }
         opts = {}
         i = 0
@@ -881,6 +921,9 @@ class PyAmppGUI(QMainWindow):
         # Context map toggles
         self.download_aia_euv.setChecked("--euv" in opts and "--no-euv" not in opts)
         self.download_aia_uv.setChecked("--uv" in opts and "--no-uv" not in opts)
+        refmaps_opt = opts.get("--refmaps-path") or opts.get("--refmap-path")
+        if refmaps_opt and hasattr(self, "refmaps_path_edit"):
+            self.refmaps_path_edit.setText(str(refmaps_opt[0]))
 
         # Disambiguation
         disambig = self._decode_meta_value(boxdata.get("metadata", {}).get("disambiguation", "")).strip().upper()
@@ -995,6 +1038,15 @@ class PyAmppGUI(QMainWindow):
         if file_name:
             self.external_box_edit.setText(file_name)
             self.update_external_box_dir()
+
+    def open_refmaps_path_dialog(self):
+        options = QFileDialog.Options()
+        options |= QFileDialog.DontUseNativeDialog
+        start_dir = self.refmaps_path_edit.text().strip() or os.getcwd()
+        file_name = QFileDialog.getExistingDirectory(self, "Select Reference Map Directory", start_dir)
+        if file_name:
+            self.refmaps_path_edit.setText(file_name)
+            self.update_refmaps_path()
 
     def add_model_configuration_section(self):
         # Hide legacy jump controls; workflow is linear with optional rebuild.
@@ -1916,18 +1968,15 @@ class PyAmppGUI(QMainWindow):
             pad_frac = None
         map_files = {}
         try:
-            dl = SDOImageDownloader(
-                Time(self.model_time_edit.dateTime().toPyDateTime()),
-                data_dir=self.sdo_data_edit.text(),
-                euv=self.download_aia_euv.isChecked(),
-                uv=self.download_aia_uv.isChecked(),
-                hmi=True,
-                backend=self._selected_download_backend(),
-            )
-            # Local file discovery only; do not trigger network fetch here.
-            map_files = dl._check_files_exist(dl.path, returnfilelist=True)
+            map_files = _discover_filesystem_maps(time_iso, self.sdo_data_edit.text())
         except Exception as exc:
             self.status_log_edit.append(f"Selector map-file discovery warning: {exc}")
+        refmaps_path = self.refmaps_path_edit.text().strip() if hasattr(self, "refmaps_path_edit") else ""
+        if refmaps_path:
+            try:
+                map_files.update(_discover_external_ref_map_files([refmaps_path]))
+            except Exception as exc:
+                self.status_log_edit.append(f"Selector reference-map discovery warning: {exc}")
         requested_map_ids = self._selector_map_ids_from_gui()
         map_ids = []
         availability = {
@@ -1943,6 +1992,10 @@ class PyAmppGUI(QMainWindow):
                     map_ids.append(map_id)
                 continue
             if map_id in map_files:
+                map_ids.append(map_id)
+        internal_source_keys = {"field", "inclination", "azimuth", "disambig", "magnetogram", "continuum"}
+        for map_id in map_files:
+            if map_id not in internal_source_keys and map_id not in map_ids:
                 map_ids.append(map_id)
         if not map_ids:
             map_ids = list(requested_map_ids)
@@ -2010,6 +2063,9 @@ class PyAmppGUI(QMainWindow):
             command += ['--use-fido']
         if not self._use_cached_downloads():
             command += ['--force-download']
+        refmaps_path = self.refmaps_path_edit.text().strip() if hasattr(self, "refmaps_path_edit") else ""
+        if refmaps_path:
+            command += ['--refmaps-path', refmaps_path]
 
         if self.save_empty_box.isChecked():
             command += ['--save-empty-box']

--- a/pyampp/gxbox/gxbox_selector_view.py
+++ b/pyampp/gxbox/gxbox_selector_view.py
@@ -740,8 +740,10 @@ def main() -> int:
     parser.add_argument("--pick", action="store_true", help="Open a file picker even if a path is provided.")
     parser.add_argument("--dir", dest="start_dir", help="Initial directory for the file picker.")
     parser.add_argument(
+        "--refmaps-path",
         "--ref-map-path",
         action="append",
+        dest="refmaps_path",
         default=[],
         help=(
             "Additional FITS file or directory of FITS files to expose as "
@@ -765,7 +767,7 @@ def main() -> int:
 
     entry_path = Path(entry_arg).expanduser().resolve()
     try:
-        session_input = _build_session_input(entry_path, ref_map_paths=args.ref_map_path)
+        session_input = _build_session_input(entry_path, ref_map_paths=args.refmaps_path)
     except Exception as exc:
         QMessageBox.critical(
             None,

--- a/pyampp/gxbox/gxbox_selector_view.py
+++ b/pyampp/gxbox/gxbox_selector_view.py
@@ -5,7 +5,7 @@ import argparse
 import re
 import shlex
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 import astropy.units as u
 import numpy as np
@@ -23,7 +23,7 @@ from pyampp.gxbox.gx_fov2box import (
     _infer_time_from_entry_loaded,
     _load_entry_box_any,
 )
-from pyampp.io import load_model, save_model
+from pyampp.io import discover_fits_refmap_map_ids, load_model, save_model
 from pyampp.gxbox.selector_api import (
     BoxGeometrySelection,
     CoordMode,
@@ -190,6 +190,36 @@ def _parse_execute_box_dims_and_dx(execute_text: str) -> tuple[Optional[tuple[in
     return dims, dx_km
 
 
+def _parse_execute_refmap_paths(execute_text: str) -> tuple[str, ...]:
+    if not execute_text:
+        return ()
+    try:
+        parts = shlex.split(str(execute_text))
+    except Exception:
+        parts = []
+    paths: list[str] = []
+    flags = {"--refmaps-path", "--refmap-path"}
+    for i, token in enumerate(parts):
+        if token in flags and i + 1 < len(parts):
+            paths.append(parts[i + 1])
+        elif token.startswith("--refmaps-path=") or token.startswith("--refmap-path="):
+            paths.append(token.split("=", 1)[1])
+    return tuple(path for path in paths if str(path).strip())
+
+
+def _merge_ref_map_paths(*path_groups: Optional[Sequence[str]]) -> tuple[str, ...]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for paths in path_groups:
+        for path in paths or ():
+            text = str(path).strip()
+            if not text or text in seen:
+                continue
+            seen.add(text)
+            merged.append(text)
+    return tuple(merged)
+
+
 def _infer_dims_from_entry(entry_loaded: dict[str, Any]) -> tuple[int, int, int]:
     meta = entry_loaded.get("metadata", {}) if isinstance(entry_loaded, dict) else {}
     axis_order = _decode_id_text(meta.get("axis_order_3d", "")).strip().lower() if isinstance(meta, dict) else ""
@@ -313,9 +343,36 @@ def _discover_filesystem_maps(time_iso: str, data_dir: Optional[str]) -> dict[st
         return {}
     try:
         downloader = SDOImageDownloader(Time(time_iso), data_dir=str(base), euv=True, uv=True, hmi=True)
-        return {k: v for k, v in downloader._check_files_exist(downloader.path, returnfilelist=True).items() if v}
+        files = {k: v for k, v in downloader._check_files_exist(downloader.path, returnfilelist=True).items() if v}
+        files.update(
+            {
+                key: value
+                for key, value in _discover_external_ref_map_files(
+                    [downloader.path],
+                    generic=False,
+                ).items()
+                if key not in files
+            }
+        )
+        return files
     except Exception:
         return {}
+
+
+def _discover_external_ref_map_files(ref_map_paths: Optional[Sequence[str]], *, generic: bool = True) -> dict[str, str]:
+    if not ref_map_paths:
+        return {}
+    out: dict[str, str] = {}
+    for path, refmap_id in discover_fits_refmap_map_ids(ref_map_paths, generic=generic).items():
+        out[_viewer_context_id_from_refmap_id(refmap_id)] = str(path)
+    return out
+
+
+def _viewer_context_id_from_refmap_id(refmap_id: str) -> str:
+    match = re.fullmatch(r"AIA_(\d+)", str(refmap_id))
+    if match:
+        return match.group(1)
+    return str(refmap_id)
 
 
 def _available_map_ids_from_sources(map_files: dict[str, str], refmaps: dict[str, dict], base_maps: dict[str, Any]) -> list[str]:
@@ -369,10 +426,37 @@ def _available_map_ids_from_sources(map_files: dict[str, str], refmaps: dict[str
             out.append(display_id)
     if "Vert_current" in refmaps and "Vert_current" not in out:
         out.append("Vert_current")
+    aliased_refmaps = {
+        "Bz_reference",
+        "Ic_reference",
+        "Vert_current",
+        "AIA_94",
+        "AIA_131",
+        "AIA_1600",
+        "AIA_1700",
+        "AIA_171",
+        "AIA_193",
+        "AIA_211",
+        "AIA_304",
+        "AIA_335",
+    }
+    for ref_key in sorted(refmaps.keys()):
+        if ref_key not in aliased_refmaps and ref_key not in out:
+            out.append(ref_key)
+    for map_id in sorted(map_files.keys()):
+        if map_id not in {
+            "magnetogram",
+            "continuum",
+            "field",
+            "inclination",
+            "azimuth",
+            "disambig",
+        } and map_id not in out:
+            out.append(map_id)
     return out or list(_DEFAULT_MAP_IDS)
 
 
-def _build_session_input(entry_path: Path) -> SelectorSessionInput:
+def _build_session_input(entry_path: Path, ref_map_paths: Optional[Sequence[str]] = None) -> SelectorSessionInput:
     entry_loaded = _load_entry_box_any(entry_path)
     if not _contains_viewer_field_payload(entry_loaded):
         raise ValueError(
@@ -385,6 +469,8 @@ def _build_session_input(entry_path: Path) -> SelectorSessionInput:
     meta = entry_loaded.get("metadata", {}) if isinstance(entry_loaded, dict) else {}
     execute_text = _decode_id_text(meta.get("execute", "")) if isinstance(meta, dict) else ""
     data_dir, _gxmodel_dir = _extract_execute_paths(execute_text)
+    execute_ref_map_paths = _parse_execute_refmap_paths(execute_text)
+    all_ref_map_paths = _merge_ref_map_paths(execute_ref_map_paths, ref_map_paths)
     explicit_fov, square_fov, explicit_fov_box = _observer_fov_from_entry(entry_loaded)
     observer_meta = entry_loaded.get("observer") if isinstance(entry_loaded, dict) else None
     observer_name = observer_meta.get("name", "earth") if isinstance(observer_meta, dict) else "earth"
@@ -414,6 +500,7 @@ def _build_session_input(entry_path: Path) -> SelectorSessionInput:
             custom_observer_source = raw_source
 
     map_files = _discover_filesystem_maps(time_iso, data_dir)
+    map_files.update(_discover_external_ref_map_files(all_ref_map_paths))
     refmaps = {}
     raw_refmaps = entry_loaded.get("refmaps")
     if isinstance(raw_refmaps, dict):
@@ -652,6 +739,15 @@ def main() -> int:
     parser.add_argument("entry_box", nargs="?", help="Path to the saved .h5 or .sav box file.")
     parser.add_argument("--pick", action="store_true", help="Open a file picker even if a path is provided.")
     parser.add_argument("--dir", dest="start_dir", help="Initial directory for the file picker.")
+    parser.add_argument(
+        "--ref-map-path",
+        action="append",
+        default=[],
+        help=(
+            "Additional FITS file or directory of FITS files to expose as "
+            "filesystem context maps. May be passed more than once."
+        ),
+    )
     args = parser.parse_args()
 
     app = QApplication.instance()
@@ -669,7 +765,7 @@ def main() -> int:
 
     entry_path = Path(entry_arg).expanduser().resolve()
     try:
-        session_input = _build_session_input(entry_path)
+        session_input = _build_session_input(entry_path, ref_map_paths=args.ref_map_path)
     except Exception as exc:
         QMessageBox.critical(
             None,

--- a/pyampp/gxbox/gxrefmap_view.py
+++ b/pyampp/gxbox/gxrefmap_view.py
@@ -43,6 +43,7 @@ _AIA_REF_CMAPS = {
 }
 _BW_SIGNED_REFMAPS = {"bx", "by", "bz", "Bz_reference"}
 _BW_SCALAR_REFMAPS = {"ic", "Ic_reference"}
+_EOVSA_REFMAP_PREFIX = "EOVSA_"
 
 
 def _decode_h5_string(value) -> str:
@@ -222,6 +223,8 @@ class RefmapViewer(QtWidgets.QMainWindow):
         norm = None
         if spec.name in _AIA_REF_CMAPS:
             cmap = sunpy_colormaps.cm.cmlist.get(_AIA_REF_CMAPS[spec.name], None)
+        elif spec.name.startswith(_EOVSA_REFMAP_PREFIX):
+            cmap = "hot"
         elif spec.name in _BW_SIGNED_REFMAPS:
             cmap = "gray"
         elif spec.name in _BW_SCALAR_REFMAPS:

--- a/pyampp/io/__init__.py
+++ b/pyampp/io/__init__.py
@@ -7,11 +7,31 @@ from .model import (
     save_model,
     save_thin_model,
 )
+from .refmaps import (
+    AddedRefmap,
+    add_fits_refmaps_from_dir_to_h5,
+    add_fits_refmaps_to_h5,
+    build_fits_refmaps_for_model,
+    build_refmap_payload_for_model,
+    discover_fits_refmap_map_ids,
+    discover_fits_refmap_paths,
+    infer_fits_refmap_id,
+    model_obstime_from_base_index,
+)
 
 __all__ = [
+    "AddedRefmap",
+    "add_fits_refmaps_from_dir_to_h5",
+    "add_fits_refmaps_to_h5",
+    "build_fits_refmaps_for_model",
+    "build_refmap_payload_for_model",
+    "discover_fits_refmap_map_ids",
+    "discover_fits_refmap_paths",
+    "infer_fits_refmap_id",
     "export_thin_model",
     "load_model",
     "load_model_metadata",
+    "model_obstime_from_base_index",
     "save_model",
     "save_thin_model",
 ]

--- a/pyampp/io/refmaps.py
+++ b/pyampp/io/refmaps.py
@@ -1,0 +1,584 @@
+"""Utilities for adding external FITS maps to pyAMPP HDF5 refmaps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+import h5py
+import numpy as np
+from astropy.io import fits
+from astropy.time import Time
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from sunpy.coordinates import Helioprojective, propagate_with_solar_surface
+from sunpy.map import Map, make_fitswcs_header
+
+from pyampp.geometry.contract import infer_obstime
+from pyampp.gxbox.boxutils import load_sunpy_map_compat
+
+
+@dataclass(frozen=True)
+class AddedRefmap:
+    """Summary for one external FITS file embedded as a refmap."""
+
+    map_id: str
+    source_path: Path
+    data_shape: tuple[int, ...]
+    data_dtype: str
+
+
+PathLike = str | Path
+MapIdFactory = Callable[[Path, object], str]
+
+
+_SOURCE_HEADER_KEYS = (
+    "TELESCOP",
+    "INSTRUME",
+    "DETECTOR",
+    "WAVELNTH",
+    "WAVEUNIT",
+    "CONTENT",
+    "BUNIT",
+    "T_OBS",
+    "T_REC",
+    "DATE",
+    "DATE-OBS",
+    "DATE_OBS",
+    "EXPTIME",
+    "LVL_NUM",
+    "QUALITY",
+    "CRVAL3",
+    "CDELT3",
+    "CUNIT3",
+    "CTYPE3",
+    "CRVAL4",
+    "CDELT4",
+    "CUNIT4",
+    "CTYPE4",
+)
+
+
+def add_fits_refmaps_to_h5(
+    h5_path: PathLike,
+    fits_paths: Iterable[PathLike],
+    *,
+    crop_refmap: str | None = "Bz_reference",
+    map_ids: Mapping[PathLike, str] | Sequence[str] | MapIdFactory | None = None,
+    overwrite: bool = False,
+) -> list[AddedRefmap]:
+    """Align external FITS maps and embed them in ``refmaps/`` of a model HDF5.
+
+    Parameters
+    ----------
+    h5_path
+        pyAMPP model HDF5 file to modify in place.
+    fits_paths
+        External FITS file paths to add.
+    crop_refmap
+        Existing refmap whose WCS footprint is used as the alignment target
+        for Earth-line-of-sight maps. Use ``None`` to embed maps without a
+        model-FOV target.
+    map_ids
+        Optional map-id source. This can be a mapping from path to id, a
+        sequence aligned with ``fits_paths``, or a callable ``(path, sunpy_map)
+        -> str``. When omitted, ids are inferred from FITS metadata and names.
+    overwrite
+        Replace existing ``refmaps/<map_id>`` groups when true.
+
+    Returns
+    -------
+    list[AddedRefmap]
+        One summary entry per embedded FITS file.
+    """
+
+    h5_path = Path(h5_path)
+    paths = [Path(p) for p in fits_paths]
+    if not paths:
+        return []
+
+    template = None
+    with h5py.File(h5_path, "r+") as h5f:
+        model_obstime = model_obstime_from_base_index(h5f)
+        refmaps = h5f.require_group("refmaps")
+        if crop_refmap is not None:
+            template = _load_template_refmap(refmaps, crop_refmap)
+
+        next_order = _next_refmap_order(refmaps)
+        out: list[AddedRefmap] = []
+        for idx, path in enumerate(paths):
+            smap = load_sunpy_map_compat(path)
+            map_id = _resolve_map_id(path, smap, map_ids, idx)
+            payload = build_refmap_payload_for_model(
+                smap,
+                model_obstime=model_obstime,
+                target_template=template,
+                source_path=path,
+            )
+
+            if map_id in refmaps:
+                if not overwrite:
+                    raise ValueError(f"refmap already exists: {map_id}")
+                del refmaps[map_id]
+
+            group = refmaps.create_group(map_id, track_order=True)
+            group.attrs["order_index"] = np.int64(next_order)
+            group.attrs["source_path"] = str(path)
+            next_order += 1
+            group.create_dataset("data", data=np.asarray(payload["data"]))
+            group.create_dataset("wcs_header", data=np.bytes_(payload["wcs_header"]))
+            out.append(
+                AddedRefmap(
+                    map_id=map_id,
+                    source_path=path,
+                    data_shape=tuple(np.asarray(payload["data"]).shape),
+                    data_dtype=str(np.asarray(payload["data"]).dtype),
+                )
+            )
+    return out
+
+
+def add_fits_refmaps_from_dir_to_h5(
+    h5_path: PathLike,
+    fits_dir: PathLike,
+    *,
+    pattern: str | None = None,
+    recursive: bool = False,
+    crop_refmap: str | None = "Bz_reference",
+    map_ids: Mapping[PathLike, str] | Sequence[str] | MapIdFactory | None = None,
+    overwrite: bool = False,
+) -> list[AddedRefmap]:
+    """Embed FITS files from a directory into ``refmaps/`` of an HDF5 model.
+
+    When ``pattern`` is omitted, all supported FITS extensions are included:
+    ``.fits``, ``.fit``, ``.fts``, their uppercase variants, and ``.fits.gz``.
+    """
+
+    fits_dir = Path(fits_dir)
+    if pattern is None:
+        paths = discover_fits_refmap_paths([fits_dir], recursive=recursive)
+    else:
+        globber = fits_dir.rglob if recursive else fits_dir.glob
+        paths = sorted(p for p in globber(pattern) if p.is_file())
+    return add_fits_refmaps_to_h5(
+        h5_path,
+        paths,
+        crop_refmap=crop_refmap,
+        map_ids=map_ids,
+        overwrite=overwrite,
+    )
+
+
+def discover_fits_refmap_paths(paths: Iterable[PathLike], *, recursive: bool = False) -> list[Path]:
+    """Resolve FITS files from a mix of file and directory paths."""
+
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for raw_path in paths or ():
+        path = Path(raw_path).expanduser()
+        candidates: list[Path]
+        if path.is_dir():
+            globber = path.rglob if recursive else path.glob
+            candidates = sorted(
+                p
+                for pattern in (
+                    "*.fits",
+                    "*.fit",
+                    "*.fts",
+                    "*.fits.gz",
+                    "*.FITS",
+                    "*.FIT",
+                    "*.FTS",
+                    "*.FITS.GZ",
+                )
+                for p in globber(pattern)
+                if p.is_file()
+            )
+        elif path.is_file():
+            candidates = [path]
+        else:
+            continue
+        for candidate in candidates:
+            resolved = candidate.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                out.append(resolved)
+    return out
+
+
+def infer_fits_refmap_id(path: PathLike, smap=None, *, generic: bool = True) -> str | None:
+    """Infer the canonical refmap id for a FITS map.
+
+    Known observation products are identified from FITS metadata. When
+    ``generic`` is true, unknown FITS files fall back to a sanitized file stem;
+    when false, unknown files are ignored by returning ``None``.
+    """
+
+    path = Path(path)
+    meta = getattr(smap, "meta", {}) or {}
+    wavelength = _meta_get(meta, "WAVELNTH")
+    telescope = str(_meta_get(meta, "TELESCOP") or "").upper()
+    instrument = str(_meta_get(meta, "INSTRUME") or "").upper()
+    if wavelength is not None and ("AIA" in telescope or "AIA" in instrument):
+        try:
+            return f"AIA_{int(round(float(wavelength)))}"
+        except Exception:
+            pass
+
+    freq = _meta_get(meta, "CRVAL3")
+    unit = str(_meta_get(meta, "CUNIT3") or "").strip().upper()
+    if freq is not None and unit == "HZ" and ("EOVSA" in telescope or "EOVSA" in instrument):
+        try:
+            return f"EOVSA_f{float(freq) / 1e9:.3f}GHz"
+        except Exception:
+            pass
+
+    if smap is None:
+        try:
+            with fits.open(path) as hdul:
+                header = None
+                for hdu in hdul:
+                    hdr = hdu.header
+                    if hdr.get("WAVELNTH") is not None or hdr.get("CRVAL3") is not None:
+                        header = hdr
+                        break
+                if header is None:
+                    header = hdul[0].header
+                return infer_fits_refmap_id(path, _HeaderOnlyMap(header), generic=generic)
+        except Exception:
+            pass
+
+    if not generic:
+        return None
+    return _sanitize_map_id(path.stem)
+
+
+def discover_fits_refmap_map_ids(
+    paths: Iterable[PathLike],
+    *,
+    recursive: bool = False,
+    generic: bool = True,
+) -> dict[Path, str]:
+    """Resolve FITS refmap paths and canonical ids using the shared IO policy."""
+
+    out: dict[Path, str] = {}
+    for path in discover_fits_refmap_paths(paths, recursive=recursive):
+        map_id = infer_fits_refmap_id(path, generic=generic)
+        if map_id:
+            out[path] = map_id
+    return out
+
+
+def build_fits_refmaps_for_model(
+    paths: Iterable[PathLike],
+    *,
+    model_obstime: str | Time | None,
+    target_fov: tuple[SkyCoord, SkyCoord] | None = None,
+    target_template=None,
+    map_ids: Mapping[PathLike, str] | Sequence[str] | MapIdFactory | None = None,
+    reproject_algorithm: str = "adaptive",
+    recursive: bool = False,
+    generic: bool = True,
+) -> dict[str, dict[str, Any]]:
+    """Load FITS refmaps from paths and build model-aligned payloads."""
+
+    if map_ids is None:
+        discovered = discover_fits_refmap_map_ids(paths, recursive=recursive, generic=generic)
+        fits_paths = list(discovered.keys())
+        resolved_map_ids: Mapping[PathLike, str] | Sequence[str] | MapIdFactory | None = discovered
+    else:
+        fits_paths = discover_fits_refmap_paths(paths, recursive=recursive)
+        resolved_map_ids = map_ids
+    out: dict[str, dict[str, Any]] = {}
+    for idx, path in enumerate(fits_paths):
+        smap = load_sunpy_map_compat(path)
+        map_id = _resolve_map_id(path, smap, resolved_map_ids, idx)
+        out[map_id] = build_refmap_payload_for_model(
+            smap,
+            model_obstime=model_obstime,
+            target_template=target_template,
+            target_fov=target_fov,
+            source_path=path,
+            reproject_algorithm=reproject_algorithm,
+        )
+    return out
+
+
+def _load_template_refmap(refmaps: h5py.Group, crop_refmap: str):
+    if crop_refmap not in refmaps:
+        raise KeyError(f"crop refmap not found: refmaps/{crop_refmap}")
+    group = refmaps[crop_refmap]
+    if "data" not in group or "wcs_header" not in group:
+        raise KeyError(f"crop refmap is missing data/wcs_header: refmaps/{crop_refmap}")
+    data = np.asarray(group["data"])
+    header_text = _decode_h5_string(group["wcs_header"][()])
+    header = fits.Header.fromstring(header_text, sep="\n")
+    return Map(np.zeros(data.shape, dtype=np.float32), header)
+
+
+def model_obstime_from_base_index(model_or_h5: Any) -> str | None:
+    """Return the model time from canonical ``base/index`` metadata."""
+
+    if isinstance(model_or_h5, (h5py.File, h5py.Group)):
+        model = {"base": {}}
+        if "base" in model_or_h5 and "index" in model_or_h5["base"]:
+            model["base"]["index"] = _decode_h5_string(model_or_h5["base/index"][()])
+        elif "base" in model_or_h5 and "index_header" in model_or_h5["base"]:
+            model["base"]["index_header"] = _decode_h5_string(model_or_h5["base/index_header"][()])
+        return infer_obstime(model)
+    if isinstance(model_or_h5, Mapping):
+        return infer_obstime(dict(model_or_h5))
+    return None
+
+
+def build_refmap_payload_for_model(
+    smap,
+    *,
+    model_obstime: str | Time | None,
+    target_template=None,
+    target_fov: tuple[SkyCoord, SkyCoord] | None = None,
+    source_path: Path | None = None,
+    reproject_algorithm: str = "adaptive",
+) -> dict[str, Any]:
+    """Build a refmap payload using pyAMPP's model-time alignment policy.
+
+    Earth-line-of-sight maps are solar-rotated to the model time and remapped
+    onto a target FOV WCS. Non-Earth maps keep their native WCS and data so the
+    viewer can display them in their own spacecraft LOS mode.
+    """
+
+    aligned = smap
+    should_reproject = _is_earth_los_map(smap)
+    if should_reproject and model_obstime is not None:
+        header = _model_fov_header_for_refmap(
+            smap,
+            model_obstime=model_obstime,
+            target_template=target_template,
+            target_fov=target_fov,
+        )
+        if header is not None:
+            with propagate_with_solar_surface():
+                aligned = smap.reproject_to(
+                    header,
+                    algorithm=reproject_algorithm,
+                    roundtrip_coords=False,
+                )
+    elif target_template is not None and should_reproject:
+        aligned = _crop_to_template_footprint(smap, target_template)
+
+    header_text = _refmap_wcs_header(
+        aligned,
+        source_path=source_path,
+        model_obstime=model_obstime,
+        source_obstime=_map_date_isot(smap),
+        aligned_to_model=bool(aligned is not smap and should_reproject),
+    )
+    return {"data": np.asarray(aligned.data), "wcs_header": header_text}
+
+
+def _model_fov_header_for_refmap(
+    smap,
+    *,
+    model_obstime: str | Time,
+    target_template=None,
+    target_fov: tuple[SkyCoord, SkyCoord] | None = None,
+):
+    observer = _earth_like_observer(smap)
+    obs_time = Time(model_obstime)
+    if target_template is not None:
+        ny, nx = np.asarray(target_template.data).shape
+        bl = target_template.pixel_to_world(0 * u.pix, 0 * u.pix)
+        tr = target_template.pixel_to_world((nx - 1) * u.pix, (ny - 1) * u.pix)
+    elif target_fov is not None:
+        bl, tr = target_fov
+    else:
+        return None
+
+    try:
+        bl_hpc = bl.transform_to(Helioprojective(observer=observer, obstime=obs_time))
+        tr_hpc = tr.transform_to(Helioprojective(observer=observer, obstime=obs_time))
+        x0, x1 = sorted([bl_hpc.Tx.to_value(u.arcsec), tr_hpc.Tx.to_value(u.arcsec)])
+        y0, y1 = sorted([bl_hpc.Ty.to_value(u.arcsec), tr_hpc.Ty.to_value(u.arcsec)])
+        scale_x = abs(float(smap.scale.axis1.to_value(u.arcsec / u.pix)))
+        scale_y = abs(float(smap.scale.axis2.to_value(u.arcsec / u.pix)))
+    except Exception:
+        return None
+    if not all(np.isfinite(v) and v > 0 for v in (scale_x, scale_y)):
+        return None
+
+    width = max(float(x1 - x0), scale_x)
+    height = max(float(y1 - y0), scale_y)
+    nx = max(2, int(np.ceil(width / scale_x)) + 1)
+    ny = max(2, int(np.ceil(height / scale_y)) + 1)
+    center = SkyCoord(
+        Tx=(0.5 * (x0 + x1)) * u.arcsec,
+        Ty=(0.5 * (y0 + y1)) * u.arcsec,
+        frame=Helioprojective(observer=observer, obstime=obs_time),
+    )
+    header = make_fitswcs_header(
+        np.empty((ny, nx), dtype=np.float32),
+        center,
+        scale=u.Quantity([scale_x, scale_y], u.arcsec / u.pix),
+    )
+    header["DATE-OBS"] = obs_time.isot
+    header["DATE_OBS"] = obs_time.isot
+    try:
+        header["RSUN_REF"] = float(smap.rsun_meters.to_value(u.m))
+    except Exception:
+        pass
+    return header
+
+
+def _crop_to_template_footprint(smap, template):
+    ny, nx = np.asarray(template.data).shape
+    bottom_left = template.pixel_to_world(0 * u.pix, 0 * u.pix)
+    top_right = template.pixel_to_world((nx - 1) * u.pix, (ny - 1) * u.pix)
+    return smap.submap(
+        bottom_left.transform_to(smap.coordinate_frame),
+        top_right=top_right.transform_to(smap.coordinate_frame),
+    )
+
+
+def _refmap_wcs_header(
+    smap,
+    *,
+    source_path: Path | None = None,
+    model_obstime: str | Time | None = None,
+    source_obstime: str | None = None,
+    aligned_to_model: bool = False,
+) -> str:
+    try:
+        header = smap.wcs.to_header()
+    except Exception:
+        header = fits.Header()
+    meta = getattr(smap, "meta", {}) or {}
+    for key in _SOURCE_HEADER_KEYS:
+        value = _meta_get(meta, key)
+        if value is not None:
+            header[key] = value
+
+    date = getattr(smap, "date", None)
+    if date is not None:
+        try:
+            header["DATE-OBS"] = date.isot
+            header["DATE_OBS"] = date.isot
+        except Exception:
+            pass
+
+    try:
+        if getattr(smap, "rsun_obs", None) is not None:
+            header["RSUN_OBS"] = float(u.Quantity(smap.rsun_obs).to_value(u.arcsec))
+    except Exception:
+        pass
+    try:
+        if getattr(smap, "rsun_meters", None) is not None:
+            header["RSUN_REF"] = float(u.Quantity(smap.rsun_meters).to_value(u.m))
+    except Exception:
+        pass
+    if source_path is not None:
+        header["HISTORY"] = f"Embedded by pyampp.io.refmaps from {source_path}"
+    if source_obstime:
+        header["SRC_DATE"] = source_obstime
+    if model_obstime is not None:
+        try:
+            header["MODELT"] = Time(model_obstime).isot
+        except Exception:
+            header["MODELT"] = str(model_obstime)
+    header["PYALIGN"] = bool(aligned_to_model)
+    return header.tostring(sep="\n", endcard=True)
+
+
+def _map_date_isot(smap) -> str | None:
+    try:
+        return smap.date.isot
+    except Exception:
+        return None
+
+
+def _is_earth_los_map(smap) -> bool:
+    meta = getattr(smap, "meta", {}) or {}
+    telescope = str(_meta_get(meta, "TELESCOP") or "").upper()
+    instrument = str(_meta_get(meta, "INSTRUME") or "").upper()
+    if any(token in telescope or token in instrument for token in ("SDO", "AIA", "HMI", "EOVSA")):
+        return True
+    try:
+        obs = smap.observer_coordinate
+        lon = abs(float(obs.lon.to_value(u.deg)))
+        lat = abs(float(obs.lat.to_value(u.deg)))
+        return lon < 5.0 and lat < 10.0
+    except Exception:
+        return False
+
+
+def _earth_like_observer(smap):
+    try:
+        return smap.observer_coordinate
+    except Exception:
+        return "earth"
+
+
+def _resolve_map_id(
+    path: Path,
+    smap,
+    map_ids: Mapping[PathLike, str] | Sequence[str] | MapIdFactory | None,
+    index: int,
+) -> str:
+    if callable(map_ids):
+        return _sanitize_map_id(map_ids(path, smap))
+    if isinstance(map_ids, Mapping):
+        if path in map_ids:
+            return _sanitize_map_id(map_ids[path])
+        if str(path) in map_ids:
+            return _sanitize_map_id(map_ids[str(path)])
+        if path.name in map_ids:
+            return _sanitize_map_id(map_ids[path.name])
+    elif map_ids is not None:
+        return _sanitize_map_id(list(map_ids)[index])
+    return _infer_map_id(path, smap)
+
+
+def _infer_map_id(path: Path, smap) -> str:
+    return infer_fits_refmap_id(path, smap, generic=True) or _sanitize_map_id(path.stem)
+
+
+class _HeaderOnlyMap:
+    def __init__(self, header: fits.Header):
+        self.meta = header
+
+
+def _sanitize_map_id(value: object) -> str:
+    text = str(value).strip()
+    text = re.sub(r"[^A-Za-z0-9_.+-]+", "_", text)
+    text = text.strip("_")
+    if not text:
+        raise ValueError("empty refmap id")
+    return text
+
+
+def _next_refmap_order(refmaps: h5py.Group) -> int:
+    orders = []
+    for name in refmaps:
+        try:
+            orders.append(int(refmaps[name].attrs.get("order_index", len(orders))))
+        except Exception:
+            orders.append(len(orders))
+    return max(orders, default=-1) + 1
+
+
+def _meta_get(meta, key: str):
+    for candidate in (key, key.lower(), key.replace("-", "_"), key.replace("_", "-")):
+        if candidate in meta:
+            value = meta[candidate]
+            if value is not None:
+                return value
+    return None
+
+
+def _decode_h5_string(value) -> str:
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    if isinstance(value, np.bytes_):
+        return bytes(value).decode(errors="replace")
+    return str(value)

--- a/pyampp/io/refmaps.py
+++ b/pyampp/io/refmaps.py
@@ -13,7 +13,7 @@ from astropy.io import fits
 from astropy.time import Time
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-from sunpy.coordinates import Helioprojective, propagate_with_solar_surface
+from sunpy.coordinates import HeliographicStonyhurst, Helioprojective, propagate_with_solar_surface
 from sunpy.map import Map, make_fitswcs_header
 
 from pyampp.geometry.contract import infer_obstime
@@ -475,6 +475,15 @@ def _refmap_wcs_header(
     try:
         if getattr(smap, "rsun_meters", None) is not None:
             header["RSUN_REF"] = float(u.Quantity(smap.rsun_meters).to_value(u.m))
+    except Exception:
+        pass
+    try:
+        obs = getattr(smap, "observer_coordinate", None)
+        obs_time = getattr(smap, "date", None)
+        if obs is not None and obs_time is not None:
+            obs_hgs = obs.transform_to(HeliographicStonyhurst(obstime=obs_time))
+            header["HGLN_OBS"] = float(obs_hgs.lon.to_value(u.deg))
+            header["HGLT_OBS"] = float(obs_hgs.lat.to_value(u.deg))
     except Exception:
         pass
     if source_path is not None:

--- a/pyampp/tests/test_downloader_drms_parallel.py
+++ b/pyampp/tests/test_downloader_drms_parallel.py
@@ -69,6 +69,50 @@ def test_download_images_drms_schedules_all_missing_products_with_worker_cap(mon
     assert result["94"] == "/fake/94.fits"
 
 
+def test_download_images_drms_keeps_returned_context_paths_when_final_scan_rejects_them(monkeypatch, tmp_path: Path) -> None:
+    when = Time("2026-04-03T19:46:37.800")
+    downloader = SDOImageDownloader(
+        when,
+        data_dir=str(tmp_path),
+        backend="drms",
+        hmi=False,
+        euv=True,
+        uv=False,
+        force_download=False,
+    )
+
+    def fake_check_files_exist(_datadir, returnfilelist=False):
+        if not returnfilelist:
+            return {}
+        return {pb: None for pb in downloader_mod.AIA_EUV_PASSBANDS}
+
+    def fake_drms_get_fits(series, segment, wave=None, time_window=12):
+        return f"/cache/aia.{wave}.fits"
+
+    class _ImmediateExecutor:
+        def __init__(self, max_workers):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            fut = concurrent.futures.Future()
+            fut.set_result(fn(*args, **kwargs))
+            return fut
+
+    monkeypatch.setattr(downloader, "_check_files_exist", fake_check_files_exist)
+    monkeypatch.setattr(downloader, "_drms_get_fits", fake_drms_get_fits)
+    monkeypatch.setattr(downloader_mod, "ThreadPoolExecutor", _ImmediateExecutor)
+
+    result = downloader._download_images_drms()
+
+    assert result["171"] == "/cache/aia.171.fits"
+
+
 def test_cache_store_concurrent_updates_preserve_all_entries(monkeypatch, tmp_path: Path) -> None:
     downloader = SDOImageDownloader(Time("2025-11-26T15:47:52"), data_dir=str(tmp_path), backend="drms")
     original_load_cache_index = downloader._load_cache_index

--- a/pyampp/tests/test_fov2box_time_anchor.py
+++ b/pyampp/tests/test_fov2box_time_anchor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import astropy.units as u
@@ -762,9 +763,10 @@ def test_normalize_runtime_stage_box_for_pipeline_uses_private_io_normalizer() -
     }
 
     captured = {}
+    contract = object()
     expected_loaded = {
         "corona": {"bx": np.ones((4, 3, 2), dtype=float)},
-        "metadata": {"axis_order_3d": "zyx"},
+        "metadata": {"axis_order_3d": "zyx", "geometry_contract": contract},
     }
 
     with patch.object(
@@ -778,7 +780,10 @@ def test_normalize_runtime_stage_box_for_pipeline_uses_private_io_normalizer() -
             stage_tag="NONE",
         )
 
-    assert normalized is expected_loaded
+    assert normalized is not expected_loaded
+    assert normalized["corona"]["bx"].shape == (2, 3, 4)
+    assert np.array_equal(normalized["corona"]["bx"], stage_box["corona"]["bx"])
+    assert normalized["metadata"]["geometry_contract"] is contract
     mocked_normalize.assert_called_once()
     payload = mocked_normalize.call_args.args[0]
     assert mocked_normalize.call_args.kwargs["source_kind"] == "h5"
@@ -1919,6 +1924,46 @@ def test_normalize_stage_for_h5_transposes_chr_2d_maps_from_xy_to_yx():
     assert np.array_equal(normalized["chromo"]["tr"], stage_box["chromo"]["tr"].T)
     assert np.array_equal(normalized["chromo"]["tr_h"], stage_box["chromo"]["tr_h"].T)
     assert np.array_equal(normalized["chromo"]["chromo_mask"], stage_box["chromo"]["chromo_mask"].T)
+
+
+def test_runtime_stage_normalization_preserves_internal_3d_order():
+    stage_box = {
+        "corona": {
+            "bx": np.zeros((4, 3, 2), dtype=float),
+            "by": np.zeros((4, 3, 2), dtype=float),
+            "bz": np.zeros((4, 3, 2), dtype=float),
+            "dr": np.ones(3, dtype=float),
+        }
+    }
+    prepared = SimpleNamespace(
+        base_group={
+            "bx": np.zeros((3, 4), dtype=float),
+            "by": np.zeros((3, 4), dtype=float),
+            "bz": np.zeros((3, 4), dtype=float),
+            "ic": np.zeros((3, 4), dtype=float),
+        },
+        base_ic_arr=np.zeros((3, 4), dtype=float),
+        refmaps={},
+        observer_metadata=None,
+        base="test",
+        projection_tag="CEA",
+    )
+    contract = object()
+
+    with patch.object(
+        gx_fov2box,
+        "_normalize_loaded_model_dict",
+        return_value={"metadata": {"geometry_contract": contract}},
+    ):
+        normalized = gx_fov2box._normalize_runtime_stage_box_for_pipeline(
+            stage_box,
+            prepared_run=prepared,
+            stage_tag="NONE",
+            source_axis_order_3d="xyz",
+        )
+
+    assert normalized["corona"]["bx"].shape == (4, 3, 2)
+    assert normalized["metadata"]["geometry_contract"] is contract
 
 
 def test_build_h5_from_sav_does_not_write_raw_sav_by_default(tmp_path):

--- a/pyampp/tests/test_fov2box_time_anchor.py
+++ b/pyampp/tests/test_fov2box_time_anchor.py
@@ -42,10 +42,12 @@ class _FakeWCS:
 class _FakeRefMap:
     def __init__(self, date: str):
         self.date = Time(date)
+        self.data = np.zeros((2, 2), dtype=float)
         self.wcs = _FakeWCS()
         self.rsun_obs = 972.3 * u.arcsec
         self.rsun_meters = 6.96e8 * u.m
         self.observer_coordinate = None
+        self.meta = {}
 
 
 class _FakeDownloader:
@@ -134,8 +136,14 @@ def test_load_hmi_maps_anchors_context_downloads_to_resolved_hmi_time():
 
 
 def test_refmap_wcs_header_preserves_date_obs():
-    header_text = gx_fov2box._refmap_wcs_header(_FakeRefMap("2025-11-26T15:34:31.400"))
-    header = fits.Header.fromstring(header_text, sep="\n")
+    from pyampp.io.refmaps import build_refmap_payload_for_model
+
+    payload = build_refmap_payload_for_model(
+        _FakeRefMap("2025-11-26T15:34:31.400"),
+        model_obstime=None,
+        target_fov=None,
+    )
+    header = fits.Header.fromstring(payload["wcs_header"], sep="\n")
     assert header["DATE-OBS"] == "2025-11-26T15:34:31.400"
     assert header["DATE_OBS"] == "2025-11-26T15:34:31.400"
     assert header["RSUN_OBS"] == 972.3
@@ -256,6 +264,7 @@ def _make_transition_cfg(**overrides):
         info=False,
         reproject_algorithm="adaptive",
         reproject_scan=None,
+        refmaps_path=None,
     )
     params.update(overrides)
     return gx_fov2box.Fov2BoxConfig(**params)
@@ -333,11 +342,25 @@ def test_prepare_observation_state_builds_expected_prepared_payload() -> None:
     class _WCSWrap:
         wcs = _WCSW()
 
+        def to_header(self):
+            header = fits.Header()
+            header["CTYPE1"] = "HPLN-TAN"
+            header["CTYPE2"] = "HPLT-TAN"
+            header["CDELT1"] = 1.0
+            header["CDELT2"] = 1.0
+            header["CRPIX1"] = 1.0
+            header["CRPIX2"] = 1.0
+            header["CUNIT1"] = "arcsec"
+            header["CUNIT2"] = "arcsec"
+            return header
+
     class _MiniMap:
         def __init__(self, data):
             self.data = np.asarray(data, dtype=float)
             self.meta = {"dummy": True}
+            self.date = Time("2025-11-26T15:34:31.400")
             self.rsun_obs = 972.3 * u.arcsec
+            self.rsun_meters = 6.96e8 * u.m
             self.scale = _Scale()
             self.wcs = _WCSWrap()
             self.dsun = 1.0 * u.m
@@ -378,8 +401,6 @@ def test_prepare_observation_state_builds_expected_prepared_payload() -> None:
     ), patch.object(
         gx_fov2box, "_build_index_header", return_value="INDEXHDR"
     ), patch.object(
-        gx_fov2box, "_refmap_wcs_header", return_value="REFHDR"
-    ), patch.object(
         gx_fov2box, "remap_vertical_current_inputs", side_effect=lambda a, b, c: (a, b, c)
     ), patch.object(
         gx_fov2box, "compute_vertical_current", return_value=np.ones((2, 2), dtype=float)
@@ -406,6 +427,164 @@ def test_prepare_observation_state_builds_expected_prepared_payload() -> None:
     assert prepared.base.endswith(".TAG.CEA")
     assert prepared.observer_metadata == {"observer": "earth"}
     assert prepared.vert_current_error is None
+
+
+def test_refmaps_path_external_refmaps_saved_in_none_stage_h5(tmp_path) -> None:
+    class _ScaleAxis:
+        def __init__(self, value):
+            self._value = value
+
+        def to_value(self, unit):
+            return self._value
+
+    class _Scale:
+        axis1 = _ScaleAxis(1.0)
+        axis2 = _ScaleAxis(1.0)
+
+    class _WCSW:
+        crpix = [1.0, 1.0]
+
+    class _WCSWrap:
+        wcs = _WCSW()
+
+        def to_header(self):
+            header = fits.Header()
+            header["CTYPE1"] = "HPLN-TAN"
+            header["CTYPE2"] = "HPLT-TAN"
+            header["CDELT1"] = 1.0
+            header["CDELT2"] = 1.0
+            header["CRPIX1"] = 1.0
+            header["CRPIX2"] = 1.0
+            header["CUNIT1"] = "arcsec"
+            header["CUNIT2"] = "arcsec"
+            return header
+
+    class _MiniMap:
+        def __init__(self, data):
+            self.data = np.asarray(data, dtype=float)
+            self.meta = {"dummy": True}
+            self.date = Time("2025-11-26T15:34:31.400")
+            self.rsun_obs = 972.3 * u.arcsec
+            self.rsun_meters = 6.96e8 * u.m
+            self.scale = _Scale()
+            self.wcs = _WCSWrap()
+
+        def reproject_to(self, header, algorithm="exact"):
+            return self
+
+    class _FakeBox:
+        def __init__(self, *args, **kwargs):
+            header = fits.Header()
+            header["CTYPE1"] = "HPLN-TAN"
+            header["CTYPE2"] = "HPLT-TAN"
+            self.bottom_cea_header = header
+
+        def bottom_top_header(self, dsun_obs=None):
+            return self.bottom_cea_header
+
+        def bounds_coords_bl_tr(self, pad_frac=0.1):
+            return (None, None)
+
+    maps = {
+        "field": _MiniMap([[1, 2], [3, 4]]),
+        "inclination": _MiniMap([[0, 0], [0, 0]]),
+        "azimuth": _MiniMap([[0, 0], [0, 0]]),
+        "continuum": _MiniMap([[10, 11], [12, 13]]),
+        "magnetogram": _MiniMap([[20, 21], [22, 23]]),
+    }
+    external_refmaps = {
+        "EOVSA_f1.418GHz": {
+            "data": np.ones((2, 2), dtype=np.float32),
+            "wcs_header": fits.Header().tostring(sep="\n", endcard=True),
+        }
+    }
+    cfg = _make_transition_cfg(
+        entry_box=None,
+        coords=(10.0, 20.0),
+        box_dims=(2, 2, 2),
+        dx_km=1400.0,
+        save_empty_box=True,
+        gxmodel_dir=str(tmp_path),
+        data_dir=str(tmp_path),
+        refmaps_path=("/tmp/external_refmaps",),
+    )
+
+    with patch.object(gx_fov2box, "_load_hmi_maps_from_downloader", return_value=(maps, {"resolved_obs_time": None})), patch.object(
+        gx_fov2box, "_resolve_cli_observer", return_value=gx_fov2box.get_earth(Time("2025-11-26T15:34:31"))
+    ), patch.object(gx_fov2box, "Box", _FakeBox), patch.object(
+        gx_fov2box, "hmi_b2ptr", return_value=(maps["field"], maps["field"], maps["field"])
+    ), patch.object(
+        gx_fov2box, "_submap_with_fov_safe", side_effect=lambda smap, bl, tr: smap
+    ), patch.object(
+        gx_fov2box, "map_from_data_header_compat", side_effect=lambda data, meta: _MiniMap(data)
+    ), patch.object(
+        gx_fov2box, "_build_index_header", return_value="INDEXHDR"
+    ), patch.object(
+        gx_fov2box, "remap_vertical_current_inputs", side_effect=lambda a, b, c: (a, b, c)
+    ), patch.object(
+        gx_fov2box, "compute_vertical_current", return_value=np.ones((2, 2), dtype=float)
+    ), patch.object(
+        gx_fov2box, "_format_coord_tag", return_value="TAG"
+    ), patch.object(
+        gx_fov2box, "_observer_metadata_from_source_map", return_value={"observer": "earth"}
+    ), patch.object(
+        gx_fov2box,
+        "build_fits_refmaps_for_model",
+        return_value=external_refmaps,
+    ) as build_external:
+        prepared = gx_fov2box._prepare_observation_state(
+            cfg,
+            Time("2025-11-26T15:34:31"),
+            (2, 2, 2),
+            lambda label, func: func(),
+            0.0,
+        )
+
+    assert prepared is not None
+    assert "EOVSA_f1.418GHz" in prepared.refmaps
+    build_external.assert_called_once()
+    assert build_external.call_args.args[0] == ("/tmp/external_refmaps",)
+
+    stage_box = {
+        "corona": {
+            "bx": np.zeros((2, 2, 2), dtype=float),
+            "by": np.zeros((2, 2, 2), dtype=float),
+            "bz": np.zeros((2, 2, 2), dtype=float),
+            "dr": prepared.dr3,
+            "attrs": {"model_type": "none"},
+        }
+    }
+    prepared_run = gx_fov2box.PreparedRunState(
+        obs_time=prepared.obs_time,
+        maps=prepared.maps,
+        base_group=prepared.base_group,
+        refmaps=prepared.refmaps,
+        base_bz_arr=prepared.base_bz_arr,
+        base_ic_arr=prepared.base_ic_arr,
+        bottom_bz_data=prepared.bottom_bz_data,
+        vert_current_error=prepared.vert_current_error,
+        projection_tag=prepared.projection_tag,
+        base=prepared.base,
+        dr3=prepared.dr3,
+        observer_metadata=prepared.observer_metadata,
+        lineage_root="OBS",
+        lineage_marker="",
+        entry_stage_for_marker="",
+    )
+    context = gx_fov2box.StageSaveContext(
+        cfg=cfg,
+        prepared_run=prepared_run,
+        execute_cmd="gx-fov2box --refmaps-path /tmp/external_refmaps",
+        out_dir=tmp_path,
+        default_grid={"voxel_id": np.zeros((2, 2, 2), dtype=np.int32)},
+        empty_grid=np.zeros((2, 2, 2), dtype=float),
+        produced=[],
+    )
+    gx_fov2box._save_stage_passthrough("NONE", stage_box, context=context)
+    out_path = tmp_path / f"{prepared.base}.NONE.h5"
+    loaded = read_b3d_h5(str(out_path))
+    assert "EOVSA_f1.418GHz" in loaded["refmaps"]
+    assert np.array_equal(loaded["refmaps"]["EOVSA_f1.418GHz"]["data"], external_refmaps["EOVSA_f1.418GHz"]["data"])
 
 
 def test_prepare_run_state_unifies_resume_and_lineage_metadata() -> None:

--- a/pyampp/tests/test_io_refmaps.py
+++ b/pyampp/tests/test_io_refmaps.py
@@ -1,0 +1,212 @@
+import h5py
+import numpy as np
+from astropy.io import fits
+
+from pyampp.io import (
+    add_fits_refmaps_from_dir_to_h5,
+    add_fits_refmaps_to_h5,
+    build_fits_refmaps_for_model,
+    discover_fits_refmap_map_ids,
+    discover_fits_refmap_paths,
+    model_obstime_from_base_index,
+)
+from pyampp.tests._fits_header import canonical_base_index_header
+
+
+def _hpc_header(
+    *,
+    shape=(8, 8),
+    crpix=(4.5, 4.5),
+    cdelt=(1.0, 1.0),
+    date_obs="2026-04-03T20:00:00.000",
+):
+    header = fits.Header()
+    header["NAXIS"] = 2
+    header["NAXIS1"] = shape[1]
+    header["NAXIS2"] = shape[0]
+    header["CTYPE1"] = "HPLN-TAN"
+    header["CTYPE2"] = "HPLT-TAN"
+    header["CUNIT1"] = "arcsec"
+    header["CUNIT2"] = "arcsec"
+    header["CRPIX1"] = crpix[0]
+    header["CRPIX2"] = crpix[1]
+    header["CRVAL1"] = 0.0
+    header["CRVAL2"] = 0.0
+    header["CDELT1"] = cdelt[0]
+    header["CDELT2"] = cdelt[1]
+    header["DATE-OBS"] = date_obs
+    header["DSUN_OBS"] = 1.496e11
+    header["RSUN_REF"] = 6.957e8
+    header["RSUN_OBS"] = 959.63
+    header["HGLN_OBS"] = 0.0
+    header["HGLT_OBS"] = 0.0
+    return header
+
+
+def _write_refmap_model(path, *, base_date_obs=None):
+    header = _hpc_header(shape=(4, 4), crpix=(2.5, 2.5))
+    with h5py.File(path, "w") as h5f:
+        if base_date_obs is not None:
+            base = h5f.create_group("base", track_order=True)
+            base.create_dataset(
+                "index",
+                data=np.bytes_(canonical_base_index_header(date_obs=base_date_obs)),
+            )
+        refmaps = h5f.create_group("refmaps", track_order=True)
+        group = refmaps.create_group("Bz_reference", track_order=True)
+        group.attrs["order_index"] = np.int64(0)
+        group.create_dataset("data", data=np.ones((4, 4), dtype=np.float32))
+        group.create_dataset("wcs_header", data=np.bytes_(header.tostring(sep="\n", endcard=True)))
+
+
+def _write_aia_fits(path, wavelength=171, date_obs="2026-04-03T20:00:00.000"):
+    header = _hpc_header(shape=(8, 8), crpix=(4.5, 4.5), date_obs=date_obs)
+    header["TELESCOP"] = "SDO/AIA"
+    header["INSTRUME"] = "AIA_3"
+    header["WAVELNTH"] = int(wavelength)
+    header["WAVEUNIT"] = "angstrom"
+    fits.PrimaryHDU(data=np.arange(64, dtype=np.float32).reshape(8, 8), header=header).writeto(path)
+
+
+def _write_eovsa_fits(path, freq_hz):
+    header = _hpc_header(shape=(8, 8), crpix=(4.5, 4.5))
+    header["TELESCOP"] = "EOVSA"
+    header["INSTRUME"] = "EOVSA"
+    header["CRVAL3"] = float(freq_hz)
+    header["CUNIT3"] = "Hz"
+    fits.PrimaryHDU(data=np.ones((8, 8), dtype=np.float32), header=header).writeto(path)
+
+
+def test_add_fits_refmaps_to_h5_crops_and_preserves_aia_metadata(tmp_path):
+    model = tmp_path / "model.h5"
+    source = tmp_path / "aia171.fits"
+    _write_refmap_model(model)
+    _write_aia_fits(source, wavelength=171)
+
+    added = add_fits_refmaps_to_h5(model, [source])
+
+    assert [item.map_id for item in added] == ["AIA_171"]
+    with h5py.File(model, "r") as h5f:
+        group = h5f["refmaps/AIA_171"]
+        assert group.attrs["order_index"] == 1
+        assert group["data"].shape == (4, 4)
+        header = fits.Header.fromstring(group["wcs_header"][()].decode(), sep="\n")
+        assert header["TELESCOP"] == "SDO/AIA"
+        assert header["WAVELNTH"] == 171
+        assert header["WAVEUNIT"] == "angstrom"
+
+
+def test_add_fits_refmaps_uses_base_index_time_for_model_alignment(tmp_path):
+    model = tmp_path / "model.h5"
+    source = tmp_path / "aia171.fits"
+    model_time = "2026-04-03T19:46:37.800"
+    source_time = "2026-04-03T19:46:33.350"
+    _write_refmap_model(model, base_date_obs=model_time)
+    _write_aia_fits(source, wavelength=171, date_obs=source_time)
+
+    with h5py.File(model, "r") as h5f:
+        assert model_obstime_from_base_index(h5f) == model_time
+
+    add_fits_refmaps_to_h5(model, [source], overwrite=True)
+
+    with h5py.File(model, "r") as h5f:
+        header = fits.Header.fromstring(h5f["refmaps/AIA_171/wcs_header"][()].decode(), sep="\n")
+        assert header["DATE-OBS"] == model_time
+        assert header["MODELT"] == model_time
+        assert header["SRC_DATE"] == source_time
+        assert header["PYALIGN"] is True
+
+
+def test_add_fits_refmaps_from_dir_to_h5_adds_all_fits(tmp_path):
+    model = tmp_path / "model.h5"
+    source_dir = tmp_path / "fits"
+    source_dir.mkdir()
+    _write_refmap_model(model)
+    _write_eovsa_fits(source_dir / "eovsa_1.fits", 1.418334960938e9)
+    _write_eovsa_fits(source_dir / "eovsa_2.fits", 2.873583984375e9)
+
+    added = add_fits_refmaps_from_dir_to_h5(model, source_dir)
+
+    assert [item.map_id for item in added] == ["EOVSA_f1.418GHz", "EOVSA_f2.874GHz"]
+    with h5py.File(model, "r") as h5f:
+        assert "EOVSA_f1.418GHz" in h5f["refmaps"]
+        assert "EOVSA_f2.874GHz" in h5f["refmaps"]
+
+
+def test_build_fits_refmaps_for_model_from_directory(tmp_path):
+    source_dir = tmp_path / "fits"
+    source_dir.mkdir()
+    _write_eovsa_fits(source_dir / "eovsa_1.fits", 1.418334960938e9)
+    _write_eovsa_fits(source_dir / "eovsa_2.fits", 2.873583984375e9)
+
+    discovered = discover_fits_refmap_paths([source_dir])
+    payloads = build_fits_refmaps_for_model(
+        [source_dir],
+        model_obstime="2026-04-03T19:46:37.800",
+        target_fov=None,
+    )
+
+    assert [p.name for p in discovered] == ["eovsa_1.fits", "eovsa_2.fits"]
+    assert set(payloads) == {"EOVSA_f1.418GHz", "EOVSA_f2.874GHz"}
+    for payload in payloads.values():
+        assert payload["data"].shape == (8, 8)
+
+
+def test_discover_fits_refmap_map_ids_known_only_excludes_hmi_wavelength(tmp_path):
+    source_dir = tmp_path / "fits"
+    source_dir.mkdir()
+    aia = source_dir / "aia171.fits"
+    _write_aia_fits(aia, wavelength=171)
+    eovsa = source_dir / "eovsa.fits"
+    _write_eovsa_fits(eovsa, 1.418334960938e9)
+
+    hmi_header = _hpc_header()
+    hmi_header["TELESCOP"] = "SDO/HMI"
+    hmi_header["INSTRUME"] = "HMI"
+    hmi_header["WAVELNTH"] = 6173
+    hmi = source_dir / "hmi_field.fits"
+    fits.PrimaryHDU(data=np.ones((8, 8), dtype=np.float32), header=hmi_header).writeto(hmi)
+
+    discovered = discover_fits_refmap_map_ids([source_dir], generic=False)
+
+    assert discovered == {
+        aia.resolve(): "AIA_171",
+        eovsa.resolve(): "EOVSA_f1.418GHz",
+    }
+
+
+def test_build_fits_refmaps_for_model_known_only_uses_shared_discovery_policy(tmp_path):
+    source_dir = tmp_path / "fits"
+    source_dir.mkdir()
+    _write_aia_fits(source_dir / "aia171.fits", wavelength=171)
+    generic_header = _hpc_header()
+    generic = source_dir / "generic_context.fits"
+    fits.PrimaryHDU(data=np.ones((8, 8), dtype=np.float32), header=generic_header).writeto(generic)
+
+    payloads = build_fits_refmaps_for_model(
+        [source_dir],
+        model_obstime="2026-04-03T19:46:37.800",
+        target_fov=None,
+        generic=False,
+    )
+
+    assert set(payloads) == {"AIA_171"}
+
+
+def test_add_fits_refmaps_to_h5_requires_overwrite_for_existing_id(tmp_path):
+    model = tmp_path / "model.h5"
+    source = tmp_path / "aia171.fits"
+    _write_refmap_model(model)
+    _write_aia_fits(source, wavelength=171)
+
+    add_fits_refmaps_to_h5(model, [source])
+    try:
+        add_fits_refmaps_to_h5(model, [source])
+    except ValueError as exc:
+        assert "refmap already exists" in str(exc)
+    else:
+        raise AssertionError("expected duplicate refmap insertion to fail")
+
+    add_fits_refmaps_to_h5(model, [source], overwrite=True)
+    with h5py.File(model, "r") as h5f:
+        assert "AIA_171" in h5f["refmaps"]

--- a/pyampp/tests/test_selector_external_refmaps.py
+++ b/pyampp/tests/test_selector_external_refmaps.py
@@ -1,0 +1,150 @@
+import numpy as np
+from astropy.io import fits
+
+from pyampp.gxbox.box_view2d import MapBoxDisplayWidget
+from pyampp.gxbox.gxbox_selector_view import (
+    _available_map_ids_from_sources,
+    _build_session_input,
+    _discover_external_ref_map_files,
+    _parse_execute_refmap_paths,
+)
+from unittest.mock import patch
+from types import SimpleNamespace
+
+
+class _FakeMap:
+    def __init__(self, data):
+        self.data = data
+        self.meta = {}
+        self.plot_settings = {}
+
+
+def test_available_map_ids_includes_external_refmaps():
+    refmaps = {
+        "Bz_reference": {"data": np.zeros((2, 2))},
+        "AIA_171": {"data": np.zeros((2, 2))},
+        "EOVSA_f1.418GHz": {"data": np.zeros((2, 2))},
+    }
+
+    map_ids = _available_map_ids_from_sources({}, refmaps, {})
+
+    assert "Bz" in map_ids
+    assert "171" in map_ids
+    assert "EOVSA_f1.418GHz" in map_ids
+
+
+def test_available_map_ids_includes_external_filesystem_maps():
+    map_ids = _available_map_ids_from_sources({"EOVSA_f1.418GHz": "/tmp/eovsa.fits"}, {}, {})
+
+    assert "EOVSA_f1.418GHz" in map_ids
+
+
+def test_embedded_refmap_key_passes_through_external_refmap_ids():
+    assert MapBoxDisplayWidget._embedded_refmap_key("171") == "AIA_171"
+    assert MapBoxDisplayWidget._embedded_refmap_key("EOVSA_f1.418GHz") == "EOVSA_f1.418GHz"
+
+
+def test_eovsa_refmaps_use_hot_temperature_colormap():
+    smap = _FakeMap(np.arange(100, dtype=float).reshape(10, 10))
+
+    MapBoxDisplayWidget._apply_display_scaling(smap, "EOVSA_f1.418GHz")
+
+    assert smap.plot_settings["cmap"] == "hot"
+    assert smap.plot_settings["norm"].vmin > 0.0
+    assert smap.plot_settings["norm"].vmax < 99.0
+
+
+def test_eovsa_context_allows_bottom_overlay():
+    assert MapBoxDisplayWidget._should_plot_bottom_overlay("EOVSA_f1.418GHz", "bz")
+
+
+def test_discover_external_ref_map_files_infers_eovsa_ids(tmp_path):
+    header = fits.Header()
+    header["CRVAL3"] = 1.418334960938e9
+    header["CUNIT3"] = "Hz"
+    header["TELESCOP"] = "EOVSA"
+    path = tmp_path / "eovsa_20260403_200000_f1.418GHz.fits"
+    fits.PrimaryHDU(data=np.ones((2, 2), dtype=np.float32), header=header).writeto(path)
+
+    discovered = _discover_external_ref_map_files([str(tmp_path)])
+
+    assert discovered == {"EOVSA_f1.418GHz": str(path)}
+
+
+def test_discover_external_ref_map_files_can_ignore_generic_fits(tmp_path):
+    generic = tmp_path / "not_a_known_context.fits"
+    fits.PrimaryHDU(data=np.ones((2, 2), dtype=np.float32)).writeto(generic)
+    aia_header = fits.Header()
+    aia_header["TELESCOP"] = "SDO/AIA"
+    aia_header["WAVELNTH"] = 171
+    aia = tmp_path / "aia171.fits"
+    fits.PrimaryHDU(data=np.ones((2, 2), dtype=np.float32), header=aia_header).writeto(aia)
+
+    discovered = _discover_external_ref_map_files([str(tmp_path)], generic=False)
+
+    assert discovered == {"171": str(aia)}
+
+
+def test_parse_execute_refmap_paths_handles_repeated_and_equals_forms():
+    execute = (
+        "gx-fov2box --refmaps-path '/tmp/eovsa maps' "
+        "--refmap-path=/tmp/extra.fits --refmaps-path /tmp/second"
+    )
+
+    assert _parse_execute_refmap_paths(execute) == (
+        "/tmp/eovsa maps",
+        "/tmp/extra.fits",
+        "/tmp/second",
+    )
+
+
+def test_build_session_input_uses_refmap_paths_from_execute_metadata(tmp_path):
+    entry_path = tmp_path / "model.NONE.h5"
+    execute_refmaps = tmp_path / "execute_refmaps"
+    explicit_refmaps = tmp_path / "explicit_refmaps"
+    execute_refmaps.mkdir()
+    explicit_refmaps.mkdir()
+    entry = {
+        "metadata": {
+            "execute": (
+                "gx-fov2box --time 2026-04-03T19:46:37 --coords -70 160 --hpc "
+                "--box-dims 4 3 2 --dx-km 1400 --data-dir /tmp/jsoc "
+                f"--refmaps-path {execute_refmaps}"
+            )
+        },
+        "corona": {
+            "bx": np.zeros((4, 3, 2), dtype=float),
+            "by": np.zeros((4, 3, 2), dtype=float),
+            "bz": np.zeros((4, 3, 2), dtype=float),
+        },
+    }
+
+    with patch("pyampp.gxbox.gxbox_selector_view._load_entry_box_any", return_value=entry), patch(
+        "pyampp.gxbox.gxbox_selector_view._discover_filesystem_maps",
+        return_value={"171": "/tmp/aia171.fits"},
+    ), patch(
+        "pyampp.gxbox.gxbox_selector_view._discover_external_ref_map_files",
+        return_value={"EOVSA_f1.418GHz": "/tmp/eovsa.fits"},
+    ) as discover_external:
+        session = _build_session_input(entry_path, ref_map_paths=[str(explicit_refmaps)])
+
+    discover_external.assert_called_once_with((str(execute_refmaps), str(explicit_refmaps)))
+    assert session.map_files["171"] == "/tmp/aia171.fits"
+    assert session.map_files["EOVSA_f1.418GHz"] == "/tmp/eovsa.fits"
+    assert "EOVSA_f1.418GHz" in session.map_ids
+
+
+def test_context_map_change_recomputes_view_instead_of_preserving_pixels():
+    widget = MapBoxDisplayWidget.__new__(MapBoxDisplayWidget)
+    widget._state = SimpleNamespace(selected_context_id="171")
+    calls = []
+
+    widget._refresh_status_text = lambda: None
+    widget._refresh_map_info = lambda: None
+    widget._refresh_plot = lambda preserve_current_view=False: calls.append(preserve_current_view)
+    widget._should_preserve_pixel_view = lambda: True
+
+    MapBoxDisplayWidget.set_context_map_id(widget, "EOVSA_f1.418GHz")
+
+    assert widget._state.selected_context_id == "EOVSA_f1.418GHz"
+    assert calls == [False]

--- a/pyampp/version.py
+++ b/pyampp/version.py
@@ -4,4 +4,4 @@ try:
     from ._version import version
 except Exception:
     # Fallback for editable/local source trees where _version.py is absent.
-    version = "1.0.1"
+    version = "1.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyampp"
-version = "1.0.1"
+version = "1.0.2"
 description = "Python Automatic Model Production Pipeline"
 readme = "README.rst"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Add `pyampp.io.refmaps` as the single policy for FITS reference-map discovery, model-time alignment from `base/index`, and HDF5 `refmaps/` embedding (AIA, EOVSA, and generic user-supplied maps).
- Wire `--refmaps-path` through `gx-fov2box` (directory embedding), the GUI (directory picker), and `gxbox-view2d` (file or directory for interactive selector context; legacy `--ref-map-path` alias retained).
- Bump release to **1.0.2** with CHANGELOG and packaging metadata updates.
- Fix DRMS downloads to retain returned AIA context FITS paths when the final cache verification pass does not list them yet.
- Fix runtime stage normalization to preserve internal 3D axis order while still injecting `geometry_contract` metadata.
- Route `Vert_current` through `build_refmap_payload_for_model` so WCS serialization and Earth-LOS alignment match other reference maps.

## Test plan

- [x] `pytest pyampp/tests/test_io_refmaps.py pyampp/tests/test_selector_external_refmaps.py`
- [x] `pytest pyampp/tests/test_downloader_drms_parallel.py pyampp/tests/test_fov2box_time_anchor.py`
- [ ] Manual: `gx-fov2box` with `--refmaps-path /path/to/refmaps_dir` and `--stop-after dl`; confirm external maps appear under `refmaps/` in the saved NONE box
- [ ] Manual: open the NONE box in `gxbox-view2d` with optional `--refmaps-path`; confirm AIA/EOVSA context maps appear in the selector menu and view reset behaves correctly when switching between maps with different resolutions


Made with [Cursor](https://cursor.com)