### PR TITLE
Pin pyAMaFiL to AMaFiL 4.4.26.601, release 1.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,24 @@ Unreleased
 - Added redundant derived ``observer/pb0r`` metadata alongside canonical
   ``observer/ephemeris`` for SSW-style ``B0 / L0 / Rsun`` interoperability.
 
+1.0.3
+-----
+
+Release focus:
+
+- pin ``pyAMaFiL`` to the June 2026 AMaFiL core until PyPI catches up.
+
+Highlights:
+
+- Pinned ``pyAMaFiL`` to Alexey Stupishin's GitHub repository at commit
+  ``3b3d141`` (AMaFiL ``4.4.26.601``). PyPI ``1.1.5`` still ships the older
+  WWNLFFF core ``4.2.25.326``, which ``pip install -U`` does not refresh when
+  the wrapper version is unchanged.
+
+Packaging/versioning:
+
+- Bumped package version to ``1.0.3`` in packaging metadata.
+
 1.0.2
 -----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@
 # -- Project information -----------------------------------------------------
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.2"
+release = "1.0.3"
 
 project = "pyAMPP"
 copyright = "2022, suncast-org"

--- a/pyampp/_version.py
+++ b/pyampp/_version.py
@@ -1,3 +1,3 @@
 """Canonical package version."""
 
-version = "1.0.2"
+version = "1.0.3"

--- a/pyampp/version.py
+++ b/pyampp/version.py
@@ -4,4 +4,4 @@ try:
     from ._version import version
 except Exception:
     # Fallback for editable/local source trees where _version.py is absent.
-    version = "1.0.2"
+    version = "1.0.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyampp"
-version = "1.0.2"
+version = "1.0.3"
 description = "Python Automatic Model Production Pipeline"
 readme = "README.rst"
 requires-python = ">=3.10"
@@ -33,7 +33,7 @@ dependencies = ["sunpy[all]",
     "pyvistaqt",
     "pyqt5",
     "scipy",
-    "pyAMaFiL",
+    "pyAMaFiL @ git+https://github.com/Alexey-Stupishin/pyAMaFiL@3b3d14181146aebefc3bf39333c4607bc155f0b9",
     "typer",
 ]
 


### PR DESCRIPTION
## Summary

- Pin `pyAMaFiL` to GitHub commit `3b3d141` (AMaFiL **4.4.26.601**). PyPI **1.1.5** still ships WWNLFFF **4.2.25.326**; a plain `pip install -U` does not refresh the native core when the wrapper version is unchanged.
- Bump pyAMPP to **1.0.3** and document the dependency change in `CHANGELOG.rst`.

## Context

Alexey Stupishin updated the AMaFiL submodule on GitHub in June 2026; that core is not on PyPI yet. pyAMPP extrapolation depends on the NLFFF reconstruction library bundled inside `pyAMaFiL`.

## Follow-up

After PyPI publishes `pyAMaFiL` with AMaFiL ≥ 4.4.26.601, revert the git URL pin to a normal PyPI dependency (see linked issue).

## Test plan

- [x] `pip install -e .` resolves `pyAMaFiL` from the pinned git commit
- [ ] `python -c "from pyAMaFiL.mag_field_wrapper import MagFieldWrapper; print(MagFieldWrapper().get_version)"` reports **4.4.26.601**


Made with [Cursor](https://cursor.com)