### PR TITLE
IDL-parity SDO cache/download (DRMS + Fido), release 1.0.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,28 @@ Unreleased
 - Added redundant derived ``observer/pb0r`` metadata alongside canonical
   ``observer/ephemeris`` for SSW-style ``B0 / L0 / Rsun`` interoperability.
 
+1.0.4
+-----
+
+Release focus:
+
+- align SDO cache/download behavior with IDL ``gx_box_jsoc_get_fits`` / ``gx_fov2box``.
+
+Highlights:
+
+- Resolve cached HMI/AIA FITS by **nearest** timestamp within the search window
+  (not first sorted glob match), matching IDL nearest-record selection.
+- Use ``index.json`` query-key cache for both DRMS and Fido backends.
+- Unify DRMS and Fido download orchestration through a shared local-resolve path.
+- Anchor AIA context downloads to HMI **continuum** ``DATE-OBS`` (IDL ``gx_fov2box``),
+  not the field-map timestamp.
+- Added ``--hmi-time-window`` and ``--aia-time-window`` CLI options (IDL
+  ``HMI_time_window`` / ``AIA_time_window``).
+
+Packaging/versioning:
+
+- Bumped package version to ``1.0.4`` in packaging metadata.
+
 1.0.3
 -----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@
 # -- Project information -----------------------------------------------------
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.3"
+release = "1.0.4"
 
 project = "pyAMPP"
 copyright = "2022, suncast-org"

--- a/pyampp/_version.py
+++ b/pyampp/_version.py
@@ -1,3 +1,3 @@
 """Canonical package version."""
 
-version = "1.0.3"
+version = "1.0.4"

--- a/pyampp/data/downloader.py
+++ b/pyampp/data/downloader.py
@@ -45,6 +45,8 @@ class SDOImageDownloader:
         force_download=False,
         poll_seconds=5,
         drms_sequential=False,
+        hmi_time_window=720,
+        aia_time_window=12,
     ):
         self.time = time if isinstance(time, Time) else Time(time)
         self.uv = uv
@@ -54,6 +56,8 @@ class SDOImageDownloader:
         self.force_download = bool(force_download)
         self.poll_seconds = max(1, int(poll_seconds))
         self.drms_sequential = bool(drms_sequential)
+        self.hmi_time_window = max(1, int(hmi_time_window))
+        self.aia_time_window = max(1, int(aia_time_window))
         self._drms_throttle_seen = False
         if self.backend not in self.SUPPORTED_BACKENDS:
             raise ValueError(
@@ -113,52 +117,162 @@ class SDOImageDownloader:
         }
         return patterns
 
+    def _time_tolerances(self):
+        uv_seconds = max(self.aia_time_window, 24) if self.uv else self.aia_time_window
+        return {
+            "euv": timedelta(seconds=self.aia_time_window),
+            "uv": timedelta(seconds=uv_seconds),
+            "hmi_b": timedelta(seconds=self.hmi_time_window),
+            "hmi_m": timedelta(seconds=self.hmi_time_window),
+            "hmi_ic": timedelta(seconds=self.hmi_time_window),
+        }
+
+    @staticmethod
+    def _parse_filename_datetime(filepath):
+        filename = os.path.basename(filepath)
+        match_aia = re.search(r"\d{4}-\d{2}-\d{2}T\d{6}Z", filename)
+        if match_aia:
+            return datetime.strptime(match_aia.group(), "%Y-%m-%dT%H%M%SZ")
+        match_hmi = re.search(r"\d{8}_\d{6}_TAI", filename)
+        if match_hmi:
+            return datetime.strptime(match_hmi.group(), "%Y%m%d_%H%M%S_TAI")
+        return None
+
+    def _find_nearest_cached_file(self, pattern_spec, tolerance_seconds):
+        if isinstance(pattern_spec, str):
+            pattern_spec = [pattern_spec]
+        matches = []
+        for pattern in pattern_spec:
+            matches.extend(glob(pattern))
+        unique_matches = sorted(set(matches))
+        target = self.time.datetime
+        tolerance = float(tolerance_seconds)
+        best_path = None
+        best_delta = None
+        for filepath in unique_matches:
+            file_dt = self._parse_filename_datetime(filepath)
+            if file_dt is None:
+                continue
+            delta = abs((file_dt - target).total_seconds())
+            if delta <= tolerance and (best_delta is None or delta < best_delta):
+                best_delta = delta
+                best_path = filepath
+        return best_path
+
+    def _tolerance_seconds_for_series(self, series, time_window):
+        if str(series or "").lower().startswith("hmi."):
+            return float(self.hmi_time_window)
+        if str(series or "").lower().startswith("aia.lev1_uv"):
+            return float(max(time_window, 24))
+        return float(time_window)
+
+    def _make_query_bounds(self, series, time_window):
+        query_window = self._query_window_seconds(series, time_window)
+        t1 = self.time - (query_window / 2.0) * u.s
+        t2 = self.time + (query_window / 2.0) * u.s
+        return t1, t2
+
+    def _try_resolve_local(self, series, segment, wave, time_window, patterns):
+        t1, t2 = self._make_query_bounds(series, time_window)
+        query_key = self._make_query_key(t1, t2, series, segment, wave=wave)
+        if not self.force_download:
+            cached = self._cache_lookup(query_key)
+            if cached:
+                print(f"  cache hit: {os.path.basename(cached)}")
+                return cached
+            tolerance = self._tolerance_seconds_for_series(series, time_window)
+            nearest = self._find_nearest_cached_file(patterns, tolerance)
+            if nearest:
+                if not self._fits_has_map_metadata(nearest):
+                    try:
+                        Path(nearest).unlink(missing_ok=True)
+                    except Exception:
+                        pass
+                else:
+                    print(f"  cache hit: {os.path.basename(nearest)}")
+                    self._cache_store(query_key, nearest)
+                    return nearest
+        return ""
+
+    def _iter_product_specs(self):
+        patterns = self._generate_filename_patterns(self.path)
+        backend_label = "DRMS" if self.backend == "drms" else "Fido"
+        specs = []
+        hmi_tasks = [
+            ("hmi.B_720s", "field", "field", "hmi_b"),
+            ("hmi.B_720s", "inclination", "inclination", "hmi_b"),
+            ("hmi.B_720s", "azimuth", "azimuth", "hmi_b"),
+            ("hmi.B_720s", "disambig", "disambig", "hmi_b"),
+            ("hmi.M_720s", "magnetogram", "magnetogram", "hmi_m"),
+            ("hmi.Ic_noLimbDark_720s", "continuum", "continuum", "hmi_ic"),
+        ]
+        if self.hmi:
+            for idx, (series, segment, key, category) in enumerate(hmi_tasks, start=1):
+                specs.append(
+                    {
+                        "key": key,
+                        "series": series,
+                        "segment": segment,
+                        "wave": None,
+                        "time_window": self.hmi_time_window,
+                        "patterns": patterns[category][key],
+                        "label": f"{backend_label} HMI: {idx}/{len(hmi_tasks)} ({segment})",
+                        "pool": "hmi",
+                    }
+                )
+        if self.euv:
+            for idx, wave in enumerate(AIA_EUV_PASSBANDS, start=1):
+                specs.append(
+                    {
+                        "key": wave,
+                        "series": "aia.lev1_euv_12s",
+                        "segment": "image",
+                        "wave": wave,
+                        "time_window": self.aia_time_window,
+                        "patterns": patterns["euv"][wave],
+                        "label": f"{backend_label} AIA EUV: {idx}/{len(AIA_EUV_PASSBANDS)} ({wave})",
+                        "pool": "aia",
+                    }
+                )
+        if self.uv:
+            uv_window = max(self.aia_time_window, 24)
+            for idx, wave in enumerate(AIA_UV_PASSBANDS, start=1):
+                specs.append(
+                    {
+                        "key": wave,
+                        "series": "aia.lev1_uv_24s",
+                        "segment": "image",
+                        "wave": wave,
+                        "time_window": uv_window,
+                        "patterns": patterns["uv"][wave],
+                        "label": f"{backend_label} AIA UV: {idx}/{len(AIA_UV_PASSBANDS)} ({wave})",
+                        "pool": "aia",
+                    }
+                )
+        return specs
+
     def _check_files_exist(self, datadir, returnfilelist=False):
         patterns = self._generate_filename_patterns(datadir)
         existence_report = {}
-
-        time_tolerances = {
-            "euv": timedelta(seconds=12),
-            "uv": timedelta(seconds=24),
-            "hmi_b": timedelta(seconds=720),
-            "hmi_m": timedelta(seconds=720),
-            "hmi_ic": timedelta(seconds=720),
-        }
-
-        def file_within_tolerance(filepath, tolerance):
-            filename = os.path.basename(filepath)
-            match_aia = re.search(r"\d{4}-\d{2}-\d{2}T\d{6}Z", filename)
-            if match_aia:
-                file_dt = datetime.strptime(match_aia.group(), "%Y-%m-%dT%H%M%SZ")
-                return abs((file_dt - self.time.datetime).total_seconds()) <= tolerance.total_seconds()
-
-            match_hmi = re.search(r"\d{8}_\d{6}_TAI", filename)
-            if match_hmi:
-                file_dt = datetime.strptime(match_hmi.group(), "%Y%m%d_%H%M%S_TAI")
-                return abs((file_dt - self.time.datetime).total_seconds()) <= tolerance.total_seconds()
-
-            return False
-
-        def find_matching_files(pattern_spec, tolerance):
-            if isinstance(pattern_spec, str):
-                pattern_spec = [pattern_spec]
-            all_matches = []
-            for pattern in pattern_spec:
-                all_matches.extend(glob(pattern))
-            unique_matches = sorted(set(all_matches))
-            return [f for f in unique_matches if file_within_tolerance(f, tolerance)]
+        time_tolerances = self._time_tolerances()
 
         if returnfilelist:
             for category, patterns_dict in patterns.items():
                 for key, pattern in patterns_dict.items():
-                    found_files = find_matching_files(pattern, time_tolerances[category])
-                    existence_report[key] = found_files[0] if found_files else None
+                    nearest = self._find_nearest_cached_file(
+                        pattern,
+                        time_tolerances[category].total_seconds(),
+                    )
+                    existence_report[key] = nearest
         else:
             for category, patterns_dict in patterns.items():
                 existence_report[category] = {}
                 for key, pattern in patterns_dict.items():
-                    found_files = find_matching_files(pattern, time_tolerances[category])
-                    existence_report[category][key] = bool(found_files)
+                    nearest = self._find_nearest_cached_file(
+                        pattern,
+                        time_tolerances[category].total_seconds(),
+                    )
+                    existence_report[category][key] = bool(nearest)
         return existence_report
 
     def download_images(self):
@@ -171,87 +285,40 @@ class SDOImageDownloader:
             self.existence_report = self._download_images_fido()
         return self.existence_report
 
-    def _download_images_fido(self):
-        all_files = {}
-        if self.euv:
-            self._handle_euv(all_files)
-        if self.uv:
-            self._handle_uv(all_files)
-        if self.hmi:
-            self._handle_hmi(all_files)
+    def _fetch_product(self, backend, job):
+        if backend == "drms":
+            return self._drms_get_fits(
+                job["series"],
+                job["segment"],
+                wave=job["wave"],
+                time_window=job["time_window"],
+            )
+        return self._fido_fetch_product(
+            job["series"],
+            job["segment"],
+            wave=job["wave"],
+            time_window=job["time_window"],
+        )
 
-        files_to_download = list(all_files.values())
-        if files_to_download:
-            self._fetch(files_to_download, overwrite=self.force_download)
-        return self._check_files_exist(self.path, returnfilelist=True)
-
-    def _download_images_drms(self):
+    def _download_images_resolved(self, backend):
         self._drms_throttle_seen = False
-        if self.drms_sequential:
+        if backend == "drms" and self.drms_sequential:
             print("DRMS sequential mode enabled: forcing single-worker downloads")
-        files = self._check_files_exist(self.path, returnfilelist=True)
-        for key, path in list(files.items()):
-            if path and not self._fits_has_map_metadata(path):
-                try:
-                    Path(path).unlink(missing_ok=True)
-                except Exception:
-                    pass
-                files[key] = None
-        if self.force_download:
-            for key in list(files.keys()):
-                files[key] = None
 
-        hmi_tasks = [
-            ("hmi.B_720s", "field", "field"),
-            ("hmi.B_720s", "inclination", "inclination"),
-            ("hmi.B_720s", "azimuth", "azimuth"),
-            ("hmi.B_720s", "disambig", "disambig"),
-            ("hmi.M_720s", "magnetogram", "magnetogram"),
-            ("hmi.Ic_noLimbDark_720s", "continuum", "continuum"),
-        ]
-        hmi_jobs = []
-        context_jobs = []
-        if self.hmi:
-            for idx, (series, segment, key) in enumerate(hmi_tasks, start=1):
-                if not files.get(key):
-                    hmi_jobs.append(
-                        {
-                            "key": key,
-                            "series": series,
-                            "segment": segment,
-                            "wave": None,
-                            "time_window": 720,
-                            "label": f"DRMS HMI: {idx}/{len(hmi_tasks)} ({segment})",
-                        }
-                    )
+        specs = self._iter_product_specs()
+        files = {}
+        for spec in specs:
+            path = self._try_resolve_local(
+                spec["series"],
+                spec["segment"],
+                spec["wave"],
+                spec["time_window"],
+                spec["patterns"],
+            )
+            files[spec["key"]] = path or None
 
-        if self.euv:
-            for idx, wave in enumerate(AIA_EUV_PASSBANDS, start=1):
-                if not files.get(wave):
-                    context_jobs.append(
-                        {
-                            "key": wave,
-                            "series": "aia.lev1_euv_12s",
-                            "segment": "image",
-                            "wave": wave,
-                            "time_window": 12,
-                            "label": f"DRMS AIA EUV: {idx}/{len(AIA_EUV_PASSBANDS)} ({wave})",
-                        }
-                    )
-
-        if self.uv:
-            for idx, wave in enumerate(AIA_UV_PASSBANDS, start=1):
-                if not files.get(wave):
-                    context_jobs.append(
-                        {
-                            "key": wave,
-                            "series": "aia.lev1_uv_24s",
-                            "segment": "image",
-                            "wave": wave,
-                            "time_window": 24,
-                            "label": f"DRMS AIA UV: {idx}/{len(AIA_UV_PASSBANDS)} ({wave})",
-                        }
-                    )
+        hmi_jobs = [spec for spec in specs if spec["pool"] == "hmi" and not files.get(spec["key"])]
+        aia_jobs = [spec for spec in specs if spec["pool"] == "aia" and not files.get(spec["key"])]
 
         def _run_jobs(jobs, workers, label):
             if not jobs:
@@ -259,20 +326,12 @@ class SDOImageDownloader:
             failed = []
             max_workers = max(1, min(workers, len(jobs)))
             if len(jobs) > 1:
-                print(f"DRMS: downloading {len(jobs)} {label} products with up to {max_workers} workers")
+                print(f"{backend.upper()}: downloading {len(jobs)} {label} products with up to {max_workers} workers")
             with ThreadPoolExecutor(max_workers=max_workers) as pool:
                 future_to_job = {}
                 for job in jobs:
                     print(job["label"])
-                    future_to_job[
-                        pool.submit(
-                            self._drms_get_fits,
-                            job["series"],
-                            job["segment"],
-                            wave=job["wave"],
-                            time_window=job["time_window"],
-                        )
-                    ] = job
+                    future_to_job[pool.submit(self._fetch_product, backend, job)] = job
                 for future in as_completed(future_to_job):
                     job = future_to_job[future]
                     try:
@@ -281,112 +340,84 @@ class SDOImageDownloader:
                             failed.append(job)
                     except Exception as exc:
                         print(
-                            "DRMS task failed for "
+                            f"{backend.upper()} task failed for "
                             f"{job['series']}{{{job['segment']}}}: {exc}"
                         )
                         files[job["key"]] = ""
                         failed.append(job)
             return failed
 
-        # HMI requests are serialized to avoid JSOC pending-export throttling.
-        hmi_workers = 1 if self.drms_sequential else self.DRMS_HMI_MAX_WORKERS
-        _run_jobs(hmi_jobs, hmi_workers, "HMI")
-        # Context AIA products keep parallelism from PR40.
-        context_workers = 1 if self.drms_sequential else self.DRMS_MAX_WORKERS
-        failed_context = _run_jobs(context_jobs, context_workers, "AIA")
-        if (
-            failed_context
-            and context_workers > 1
-            and self._drms_throttle_seen
-        ):
-            retry_jobs = [job for job in failed_context if not files.get(job["key"])]
-            if retry_jobs:
-                print(
-                    "DRMS throttling detected during AIA parallel fetch; "
-                    "retrying missing AIA products sequentially"
-                )
-                self._drms_throttle_seen = False
-                _run_jobs(retry_jobs, 1, "AIA retry")
-
-        verified_files = self._check_files_exist(self.path, returnfilelist=True)
-        for key, path in files.items():
-            if path and not verified_files.get(key):
-                verified_files[key] = path
-        return verified_files
-
-    def _handle_euv(self, all_files):
-        if self.force_download:
-            missing_euv = AIA_EUV_PASSBANDS
-        elif self.existence_report:
-            missing_euv = [pb for pb, exists in self.existence_report.get("euv", {}).items() if not exists]
+        if backend == "drms":
+            hmi_workers = 1 if self.drms_sequential else self.DRMS_HMI_MAX_WORKERS
+            _run_jobs(hmi_jobs, hmi_workers, "HMI")
+            context_workers = 1 if self.drms_sequential else self.DRMS_MAX_WORKERS
+            failed_context = _run_jobs(aia_jobs, context_workers, "AIA")
+            if failed_context and context_workers > 1 and self._drms_throttle_seen:
+                retry_jobs = [job for job in failed_context if not files.get(job["key"])]
+                if retry_jobs:
+                    print(
+                        "DRMS throttling detected during AIA parallel fetch; "
+                        "retrying missing AIA products sequentially"
+                    )
+                    self._drms_throttle_seen = False
+                    _run_jobs(retry_jobs, 1, "AIA retry")
         else:
-            missing_euv = AIA_EUV_PASSBANDS
+            _run_jobs(hmi_jobs, 1, "HMI")
+            _run_jobs(aia_jobs, 1, "AIA")
 
-        if missing_euv:
-            missing_euv = [int(pb) for pb in missing_euv]
-            wavelength_attr = a.AttrOr([a.Wavelength(pb * u.AA) for pb in missing_euv])
-            all_files["euv"] = self._search(
-                "aia.lev1_euv_12s",
-                wavelength=wavelength_attr,
-                segments=a.jsoc.Segment("image"),
-            )
+        return {key: (path or "") for key, path in files.items()}
 
-    def _handle_uv(self, all_files):
-        if self.force_download:
-            missing_uv = AIA_UV_PASSBANDS
-        elif self.existence_report:
-            missing_uv = [pb for pb, exists in self.existence_report.get("uv", {}).items() if not exists]
-        else:
-            missing_uv = AIA_UV_PASSBANDS
+    def _download_images_fido(self):
+        return self._download_images_resolved("fido")
 
-        if missing_uv:
-            missing_uv = [int(pb) for pb in missing_uv]
-            wavelength_attr = a.AttrOr([a.Wavelength(pb * u.AA) for pb in missing_uv])
-            all_files["uv"] = self._search(
-                "aia.lev1_uv_24s",
-                wavelength=wavelength_attr,
-                segments=a.jsoc.Segment("image"),
-            )
+    def _download_images_drms(self):
+        return self._download_images_resolved("drms")
 
-    def _handle_hmi(self, all_files):
-        if self.force_download:
-            missing_hmi_b = HMI_B_SEGMENTS
-            missing_hmi_m = True
-            missing_hmi_ic = True
-        elif self.existence_report:
-            missing_hmi_b = [seg for seg, exists in self.existence_report.get("hmi_b", {}).items() if not exists]
-            missing_hmi_m = not self.existence_report.get("hmi_m", {}).get("magnetogram", True)
-            missing_hmi_ic = not self.existence_report.get("hmi_ic", {}).get("continuum", True)
-        else:
-            missing_hmi_b = HMI_B_SEGMENTS
-            missing_hmi_m = True
-            missing_hmi_ic = True
+    def _fido_fetch_product(self, series, segment, wave=None, time_window=12):
+        t1, t2 = self._make_query_bounds(series, time_window)
+        query_key = self._make_query_key(t1, t2, series, segment, wave=wave)
 
-        if missing_hmi_b:
-            segment_attr = a.AttrAnd([a.jsoc.Segment(seg) for seg in missing_hmi_b])
-            all_files["hmi_b"] = self._search("hmi.B_720s", segments=segment_attr)
-        if missing_hmi_m:
-            all_files["hmi_m"] = self._search("hmi.M_720s", segments=a.jsoc.Segment("magnetogram"))
-        if missing_hmi_ic:
-            all_files["hmi_ic"] = self._search("hmi.Ic_noLimbDark_720s", segments=a.jsoc.Segment("continuum"))
-
-    def _search(self, series, segments=None, wavelength=None):
         notify_email = jsoc_notify_email()
-        search_attrs = [a.Time(self.time, self.time), a.jsoc.Series(series), a.jsoc.Notify(notify_email)]
-        if wavelength:
-            search_attrs.insert(-1, wavelength)
-        if segments:
-            search_attrs.insert(-1, segments)
+        search_attrs = [a.Time(t1, t2), a.jsoc.Series(series), a.jsoc.Notify(notify_email)]
+        if wave is not None:
+            search_attrs.insert(-1, a.Wavelength(int(wave) * u.AA))
+        search_attrs.insert(-1, a.jsoc.Segment(segment))
 
         print(f"Searching for {series} with attributes {search_attrs}")
         result = Fido.search(*search_attrs)
         print(f"Found {len(result)} records for download.")
-        return result
+        if len(result) == 0:
+            return ""
 
-    def _fetch(self, files_to_download, streams=5, overwrite=False):
-        fetched_files = Fido.fetch(*files_to_download, path=self.path, overwrite=overwrite, max_conn=streams)
+        fetched_files = Fido.fetch(
+            *result,
+            path=self.path,
+            overwrite=self.force_download,
+            max_conn=1,
+        )
         print(f"Downloaded {len(fetched_files)} files.")
-        return fetched_files
+        if not fetched_files:
+            return ""
+
+        best_path = ""
+        best_delta = None
+        target = self.time.datetime
+        for item in fetched_files:
+            path = str(item)
+            if not self._fits_has_map_metadata(path):
+                continue
+            file_dt = self._parse_filename_datetime(path)
+            if file_dt is None:
+                if not best_path:
+                    best_path = path
+                continue
+            delta = abs((file_dt - target).total_seconds())
+            if best_delta is None or delta < best_delta:
+                best_delta = delta
+                best_path = path
+        if best_path:
+            self._cache_store(query_key, best_path)
+        return best_path
 
     def _load_cache_index(self):
         if not self._cache_index_path.exists():
@@ -712,9 +743,7 @@ class SDOImageDownloader:
             return False
 
     def _drms_get_fits(self, series, segment, wave=None, time_window=12):
-        query_window = self._query_window_seconds(series, time_window)
-        t1 = self.time - (query_window / 2.0) * u.s
-        t2 = self.time + (query_window / 2.0) * u.s
+        t1, t2 = self._make_query_bounds(series, time_window)
         query_key = self._make_query_key(t1, t2, series, segment, wave=wave)
 
         if not self.force_download:

--- a/pyampp/gxbox/gx_fov2box.py
+++ b/pyampp/gxbox/gx_fov2box.py
@@ -283,6 +283,8 @@ class Fov2BoxConfig:
     download_backend: str
     drms_sequential: bool
     force_download: bool
+    hmi_time_window: float
+    aia_time_window: float
     entry_box: Optional[str]
     save_empty_box: bool
     save_potential: bool
@@ -851,6 +853,8 @@ def _prepare_observation_state(
         download_backend=cfg.download_backend,
         drms_sequential=cfg.drms_sequential,
         force_download=cfg.force_download,
+        hmi_time_window=cfg.hmi_time_window,
+        aia_time_window=cfg.aia_time_window,
         disambig_method=disambig_method,
         strict_required=(_last_stage_tag(cfg.stop_after) != "DL"),
     )
@@ -2320,6 +2324,10 @@ def _build_execute_cmd(cfg: Fov2BoxConfig) -> str:
         cmd.append("--use-fido")
     if cfg.force_download:
         cmd.append("--force-download")
+    if cfg.hmi_time_window != 720:
+        cmd += ["--hmi-time-window", f"{cfg.hmi_time_window:.6g}"]
+    if cfg.aia_time_window != 12:
+        cmd += ["--aia-time-window", f"{cfg.aia_time_window:.6g}"]
     if cfg.euv:
         cmd.append("--euv")
     if cfg.uv:
@@ -2697,6 +2705,8 @@ def _print_info(cfg: Fov2BoxConfig) -> None:
         ("download_backend", cfg.download_backend, "SDO downloader backend"),
         ("drms_sequential", cfg.drms_sequential, "Force single-worker DRMS downloads (HMI and AIA)"),
         ("force_download", cfg.force_download, "Bypass local cache hits and redownload requested SDO products"),
+        ("hmi_time_window", cfg.hmi_time_window, "HMI JSOC search window in seconds (IDL HMI_time_window)"),
+        ("aia_time_window", cfg.aia_time_window, "AIA JSOC search window in seconds (IDL AIA_time_window)"),
         ("entry_box", cfg.entry_box, "Path to precomputed HDF5 box"),
         ("save_empty_box", cfg.save_empty_box, "Save NONE stage"),
         ("save_potential", cfg.save_potential, "Save POT stage"),
@@ -2752,6 +2762,8 @@ def _load_hmi_maps_from_downloader(
     download_backend: str = "drms",
     drms_sequential: bool = False,
     force_download: bool = False,
+    hmi_time_window: float = 720,
+    aia_time_window: float = 12,
     disambig_method: int = 2,
     strict_required: bool = True,
 ) -> tuple[Dict[str, Map], dict]:
@@ -2774,6 +2786,8 @@ def _load_hmi_maps_from_downloader(
             "hmi": want_hmi,
             "backend": download_backend,
             "force_download": force_download,
+            "hmi_time_window": hmi_time_window,
+            "aia_time_window": aia_time_window,
         }
         if download_backend == "drms":
             kwargs["drms_sequential"] = drms_sequential
@@ -2840,7 +2854,8 @@ def _load_hmi_maps_from_downloader(
         "continuum": map_conti,
         "magnetogram": map_losma,
     }
-    resolved_obs_time = Time(map_field.date) if getattr(map_field, "date", None) is not None else requested_time
+    continuum_date = getattr(map_conti, "date", None)
+    resolved_obs_time = Time(continuum_date) if continuum_date is not None else requested_time
 
     context_elapsed = 0.0
     if euv or uv:
@@ -3109,6 +3124,8 @@ def main(
     use_fido: bool = typer.Option(False, "--use-fido", help="Use the legacy SunPy/Fido downloader instead of the default DRMS backend"),
     drms_sequential: bool = typer.Option(False, "--drms-sequential", help="Force DRMS downloads to single-worker mode for maximum reliability"),
     force_download: bool = typer.Option(False, "--force-download", help="Bypass local cache hits and redownload requested SDO products"),
+    hmi_time_window: float = typer.Option(720.0, "--hmi-time-window", help="HMI JSOC search window in seconds (default 720, IDL HMI_time_window)"),
+    aia_time_window: float = typer.Option(12.0, "--aia-time-window", help="AIA JSOC search window in seconds (default 12; UV uses max(12, 24), IDL AIA_time_window)"),
     entry_box: Optional[str] = typer.Option(None, "--entry-box", help="Existing HDF5/SAV box"),
     save_empty_box: bool = typer.Option(False, "--save-empty-box", help="Save NONE stage"),
     save_potential: bool = typer.Option(False, "--save-potential", help="Save POT stage"),
@@ -3182,6 +3199,8 @@ def main(
         download_backend=download_backend or "drms",
         drms_sequential=drms_sequential,
         force_download=force_download,
+        hmi_time_window=hmi_time_window,
+        aia_time_window=aia_time_window,
         entry_box=entry_box,
         save_empty_box=save_empty_box,
         save_potential=save_potential,

--- a/pyampp/tests/test_downloader_cache_nearest.py
+++ b/pyampp/tests/test_downloader_cache_nearest.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from astropy.io import fits
+from astropy.time import Time
+
+from pyampp.data.downloader import SDOImageDownloader
+
+
+def _write_map_fits(path: Path, date_obs: str) -> None:
+    header = fits.Header()
+    header["DATE-OBS"] = date_obs
+    header["CTYPE1"] = "HPLN-TAN"
+    fits.PrimaryHDU(data=[[0.0]], header=header).writeto(path, overwrite=True)
+
+
+def test_find_nearest_cached_file_prefers_closer_hmi_bundle(tmp_path: Path) -> None:
+    day_dir = tmp_path / "2026-04-03"
+    day_dir.mkdir()
+    early = day_dir / "hmi.B_720s.20260403_193600_TAI.field.fits"
+    late = day_dir / "hmi.B_720s.20260403_194800_TAI.field.fits"
+    _write_map_fits(early, "2026-04-03T19:34:37")
+    _write_map_fits(late, "2026-04-03T19:48:00")
+
+    downloader = SDOImageDownloader(
+        Time("2026-04-03T19:46:37"),
+        data_dir=str(tmp_path),
+        backend="drms",
+        hmi=True,
+        euv=False,
+        uv=False,
+    )
+
+    patterns = downloader._generate_filename_patterns(str(day_dir))["hmi_b"]["field"]
+    nearest = downloader._find_nearest_cached_file(patterns, downloader.hmi_time_window)
+    assert nearest == str(late)
+
+
+def test_try_resolve_local_uses_index_json_without_network(tmp_path: Path) -> None:
+    day_dir = tmp_path / "2026-04-03"
+    day_dir.mkdir()
+    fits_path = day_dir / "aia.lev1_euv_12s.2026-04-03T194623Z.image.131.fits"
+    _write_map_fits(fits_path, "2026-04-03T19:46:23")
+
+    downloader = SDOImageDownloader(
+        Time("2026-04-03T19:46:37"),
+        data_dir=str(tmp_path),
+        backend="fido",
+        hmi=False,
+        euv=True,
+        uv=False,
+    )
+    patterns = downloader._generate_filename_patterns(str(day_dir))["euv"]["131"]
+    t1, t2 = downloader._make_query_bounds("aia.lev1_euv_12s", downloader.aia_time_window)
+    query_key = downloader._make_query_key(t1, t2, "aia.lev1_euv_12s", "image", wave="131")
+    downloader._cache_store(query_key, str(fits_path))
+
+    resolved = downloader._try_resolve_local(
+        "aia.lev1_euv_12s",
+        "image",
+        "131",
+        downloader.aia_time_window,
+        patterns,
+    )
+    assert resolved == str(fits_path)

--- a/pyampp/tests/test_downloader_drms_parallel.py
+++ b/pyampp/tests/test_downloader_drms_parallel.py
@@ -17,15 +17,8 @@ def test_download_images_drms_schedules_all_missing_products_with_worker_cap(mon
     hmi_keys = ["field", "inclination", "azimuth", "disambig", "magnetogram", "continuum"]
     expected_count = len(hmi_keys) + len(downloader_mod.AIA_EUV_PASSBANDS) + len(downloader_mod.AIA_UV_PASSBANDS)
 
-    check_calls = {"count": 0}
-
-    def fake_check_files_exist(_datadir, returnfilelist=False):
-        if not returnfilelist:
-            return {}
-        check_calls["count"] += 1
-        if check_calls["count"] == 1:
-            return {k: None for k in hmi_keys + downloader_mod.AIA_EUV_PASSBANDS + downloader_mod.AIA_UV_PASSBANDS}
-        return {k: f"/fake/{k}.fits" for k in hmi_keys + downloader_mod.AIA_EUV_PASSBANDS + downloader_mod.AIA_UV_PASSBANDS}
+    def fake_try_resolve_local(*_args, **_kwargs):
+        return ""
 
     drms_calls = []
 
@@ -54,7 +47,7 @@ def test_download_images_drms_schedules_all_missing_products_with_worker_cap(mon
                 fut.set_exception(exc)
             return fut
 
-    monkeypatch.setattr(downloader, "_check_files_exist", fake_check_files_exist)
+    monkeypatch.setattr(downloader, "_try_resolve_local", fake_try_resolve_local)
     monkeypatch.setattr(downloader, "_drms_get_fits", fake_drms_get_fits)
     monkeypatch.setattr(downloader_mod, "ThreadPoolExecutor", _ImmediateExecutor)
 
@@ -65,8 +58,8 @@ def test_download_images_drms_schedules_all_missing_products_with_worker_cap(mon
     assert captured_workers[1] == downloader.DRMS_MAX_WORKERS
     assert any(series == "aia.lev1_euv_12s" and segment == "image" and wave == "94" for series, segment, wave, _ in drms_calls)
     assert any(series == "hmi.B_720s" and segment == "field" and wave is None for series, segment, wave, _ in drms_calls)
-    assert result["field"] == "/fake/field.fits"
-    assert result["94"] == "/fake/94.fits"
+    assert result["field"] == "/fake/hmi.B_720s.field.fits"
+    assert result["94"] == "/fake/aia.lev1_euv_12s.94.fits"
 
 
 def test_download_images_drms_keeps_returned_context_paths_when_final_scan_rejects_them(monkeypatch, tmp_path: Path) -> None:
@@ -81,10 +74,8 @@ def test_download_images_drms_keeps_returned_context_paths_when_final_scan_rejec
         force_download=False,
     )
 
-    def fake_check_files_exist(_datadir, returnfilelist=False):
-        if not returnfilelist:
-            return {}
-        return {pb: None for pb in downloader_mod.AIA_EUV_PASSBANDS}
+    def fake_try_resolve_local(*_args, **_kwargs):
+        return ""
 
     def fake_drms_get_fits(series, segment, wave=None, time_window=12):
         return f"/cache/aia.{wave}.fits"
@@ -104,7 +95,7 @@ def test_download_images_drms_keeps_returned_context_paths_when_final_scan_rejec
             fut.set_result(fn(*args, **kwargs))
             return fut
 
-    monkeypatch.setattr(downloader, "_check_files_exist", fake_check_files_exist)
+    monkeypatch.setattr(downloader, "_try_resolve_local", fake_try_resolve_local)
     monkeypatch.setattr(downloader, "_drms_get_fits", fake_drms_get_fits)
     monkeypatch.setattr(downloader_mod, "ThreadPoolExecutor", _ImmediateExecutor)
 
@@ -205,15 +196,8 @@ def test_download_images_drms_degrades_context_to_sequential_on_throttle(monkeyp
     hmi_keys = ["field", "inclination", "azimuth", "disambig", "magnetogram", "continuum"]
     all_keys = hmi_keys + downloader_mod.AIA_EUV_PASSBANDS + downloader_mod.AIA_UV_PASSBANDS
 
-    check_calls = {"count": 0}
-
-    def fake_check_files_exist(_datadir, returnfilelist=False):
-        if not returnfilelist:
-            return {}
-        check_calls["count"] += 1
-        if check_calls["count"] == 1:
-            return {k: None for k in all_keys}
-        return {k: f"/fake/{k}.fits" for k in all_keys}
+    def fake_try_resolve_local(*_args, **_kwargs):
+        return ""
 
     attempts = {}
 
@@ -246,7 +230,7 @@ def test_download_images_drms_degrades_context_to_sequential_on_throttle(monkeyp
                 fut.set_exception(exc)
             return fut
 
-    monkeypatch.setattr(downloader, "_check_files_exist", fake_check_files_exist)
+    monkeypatch.setattr(downloader, "_try_resolve_local", fake_try_resolve_local)
     monkeypatch.setattr(downloader, "_drms_get_fits", fake_drms_get_fits)
     monkeypatch.setattr(downloader_mod, "ThreadPoolExecutor", _ImmediateExecutor)
 
@@ -269,15 +253,8 @@ def test_download_images_drms_sequential_flag_forces_single_worker(monkeypatch, 
     hmi_keys = ["field", "inclination", "azimuth", "disambig", "magnetogram", "continuum"]
     all_keys = hmi_keys + downloader_mod.AIA_EUV_PASSBANDS + downloader_mod.AIA_UV_PASSBANDS
 
-    check_calls = {"count": 0}
-
-    def fake_check_files_exist(_datadir, returnfilelist=False):
-        if not returnfilelist:
-            return {}
-        check_calls["count"] += 1
-        if check_calls["count"] == 1:
-            return {k: None for k in all_keys}
-        return {k: f"/fake/{k}.fits" for k in all_keys}
+    def fake_try_resolve_local(*_args, **_kwargs):
+        return ""
 
     def fake_drms_get_fits(series, segment, wave=None, time_window=12):
         suffix = wave if wave is not None else segment
@@ -300,7 +277,7 @@ def test_download_images_drms_sequential_flag_forces_single_worker(monkeypatch, 
             fut.set_result(fn(*args, **kwargs))
             return fut
 
-    monkeypatch.setattr(downloader, "_check_files_exist", fake_check_files_exist)
+    monkeypatch.setattr(downloader, "_try_resolve_local", fake_try_resolve_local)
     monkeypatch.setattr(downloader, "_drms_get_fits", fake_drms_get_fits)
     monkeypatch.setattr(downloader_mod, "ThreadPoolExecutor", _ImmediateExecutor)
 

--- a/pyampp/tests/test_fov2box_time_anchor.py
+++ b/pyampp/tests/test_fov2box_time_anchor.py
@@ -53,7 +53,20 @@ class _FakeRefMap:
 class _FakeDownloader:
     calls: list[dict[str, object]] = []
 
-    def __init__(self, time, uv=True, euv=True, hmi=True, data_dir=None, backend="drms", force_download=False, poll_seconds=5):
+    def __init__(
+        self,
+        time,
+        uv=True,
+        euv=True,
+        hmi=True,
+        data_dir=None,
+        backend="drms",
+        force_download=False,
+        poll_seconds=5,
+        hmi_time_window=720,
+        aia_time_window=12,
+        **kwargs,
+    ):
         self.time = Time(time)
         self.uv = uv
         self.euv = euv
@@ -97,12 +110,14 @@ class _FakeDownloader:
 
 
 def _fake_map_loader(path):
+    if path == "continuum.fits":
+        return _FakeMap("2025-11-26T15:48:00.000")
     if path == "field.fits":
         return _FakeMap("2025-11-26T15:34:31.400")
     return _FakeMap("2025-11-26T15:34:31.400")
 
 
-def test_load_hmi_maps_anchors_context_downloads_to_resolved_hmi_time():
+def test_load_hmi_maps_anchors_context_downloads_to_continuum_time():
     _FakeDownloader.calls.clear()
     requested = Time("2025-11-26T15:47:52")
     with patch.object(gx_fov2box, "SDOImageDownloader", _FakeDownloader), patch.object(
@@ -123,14 +138,15 @@ def test_load_hmi_maps_anchors_context_downloads_to_resolved_hmi_time():
     assert _FakeDownloader.calls[0]["euv"] is False
     assert _FakeDownloader.calls[0]["uv"] is False
 
-    assert _FakeDownloader.calls[1]["time"] == "2025-11-26T15:34:31.400"
+    assert _FakeDownloader.calls[1]["time"] == "2025-11-26T15:48:00.000"
     assert _FakeDownloader.calls[1]["hmi"] is False
     assert _FakeDownloader.calls[1]["euv"] is True
     assert _FakeDownloader.calls[1]["uv"] is True
 
     assert info["requested_obs_time"] == requested.isot
-    assert info["resolved_obs_time"] == "2025-11-26T15:34:31.400"
+    assert info["resolved_obs_time"] == "2025-11-26T15:48:00.000"
     assert maps["field"].date.isot == "2025-11-26T15:34:31.400"
+    assert maps["continuum"].date.isot == "2025-11-26T15:48:00.000"
     assert "AIA_94" in maps
     assert "AIA_1700" in maps
 
@@ -229,6 +245,8 @@ def _make_transition_cfg(**overrides):
         download_backend="drms",
         drms_sequential=False,
         force_download=False,
+        hmi_time_window=720.0,
+        aia_time_window=12.0,
         entry_box="/tmp/model.h5",
         save_empty_box=False,
         save_potential=False,

--- a/pyampp/version.py
+++ b/pyampp/version.py
@@ -4,4 +4,4 @@ try:
     from ._version import version
 except Exception:
     # Fallback for editable/local source trees where _version.py is absent.
-    version = "1.0.3"
+    version = "1.0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyampp"
-version = "1.0.3"
+version = "1.0.4"
 description = "Python Automatic Model Production Pipeline"
 readme = "README.rst"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Resolve cached HMI/AIA FITS by **nearest** timestamp within the search window (not first sorted glob match).
- Use `index.json` query-key cache for **both** DRMS and Fido backends.
- Unify download orchestration through a shared local-resolve path (`_try_resolve_local` → fetch).
- Anchor AIA context downloads on HMI **continuum** `DATE-OBS` (IDL `gx_fov2box`), not field-map time.
- Add `--hmi-time-window` (default 720) and `--aia-time-window` (default 12) CLI options.

## Validation

- Unit tests: nearest cache selection, index hit without network, continuum time anchor.
- Manual: full `gx-fov2box` on CESRA 2026-04-03 box — downloads in **0.74s** (all cache hits), pipeline completed through **NAS.GEN.CHR** (~467s total).

## Test plan

- [x] `pytest pyampp/tests/test_downloader_cache_nearest.py pyampp/tests/test_downloader_drms_parallel.py`
- [x] Manual CESRA run with existing `jsoc_cache` (no JSOC re-export)
- [x] Full chr pipeline on 300×301×250 box completes without OOM


Made with [Cursor](https://cursor.com)