### PR TITLE
Address Copilot PR review follow-ups (1.0.5)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,32 +4,26 @@ Changelog
 Unreleased
 ----------
 
-- Retired the legacy ``gxbox`` GUI entrypoint from the public package surface.
-- Retired the compatibility aliases ``gxbox-view`` and ``gxbox-select`` from the public package surface.
-- Repositioned ``pyampp`` as the main GUI application and clarified the distinct roles of:
-  - ``gxbox-view2d``
-  - ``gxbox-view3d``
-  - ``gxrefmap-view``
-- ``h5tree`` now prints ``metadata/*`` values by default.
-- Replaced ``--show-metadata`` with ``--no-metadata`` to explicitly suppress metadata output.
-- Added ``--meta`` mode to print only ``metadata/*`` values (without tree output).
-- Simplified GUI launcher commands: removed ``gxampp`` alias; use ``pyampp`` as the single launcher.
-- Added a DRMS downloader backend and made it the default backend.
-- Added ``--use-fido`` to explicitly select the legacy SunPy/Fido downloader.
-- Added ``--force-download`` to bypass cache hits for clean downloader benchmarking.
-- Improved DRMS downloader throughput by scheduling independent HMI/AIA requests concurrently.
-- Added GUI downloader controls:
-  - ``Downloader`` selector (`DRMS` / `Fido`)
-  - ``Use cache`` checkbox
-- Added GUI command-export actions for the current ``gx-fov2box`` script:
-  - copy command
-  - save shell script
-- Implemented DRMS normalization of raw JSOC exports into reusable local FITS files.
-- Fixed DRMS nearest-record selection for HMI products so cadence choice now matches the intended IDL-style behavior.
-- Reworked ``Vert_current`` generation to use an IDL-style remapped-input path plus a vectorized NumPy kernel.
-- Fixed 2D viewer loading of embedded-only maps such as ``Vert_current`` when ``Map Source`` is set to ``Filesystem``.
-- Added redundant derived ``observer/pb0r`` metadata alongside canonical
-  ``observer/ephemeris`` for SSW-style ``B0 / L0 / Rsun`` interoperability.
+1.0.5
+-----
+
+Release focus:
+
+- address Copilot PR review follow-ups from releases 1.0.3 and 1.0.4.
+
+Highlights:
+
+- Align local cache tolerance with JSOC query bounds by using half the
+  configured query window for nearest-file matching (consistent with
+  ``_make_query_bounds()``).
+- Restore batched Fido ``search`` / ``fetch`` for AIA wavelengths and HMI
+  segment groups instead of one network round-trip per product.
+- Reorganize changelog: move previously shipped notes out of ``Unreleased``
+  into their release sections.
+
+Packaging/versioning:
+
+- Bumped package version to ``1.0.5`` in packaging metadata.
 
 1.0.4
 -----
@@ -66,6 +60,29 @@ Highlights:
   ``3b3d141`` (AMaFiL ``4.4.26.601``). PyPI ``1.1.5`` still ships the older
   WWNLFFF core ``4.2.25.326``, which ``pip install -U`` does not refresh when
   the wrapper version is unchanged.
+- Retired the legacy ``gxbox`` GUI entrypoint from the public package surface.
+- Retired the compatibility aliases ``gxbox-view`` and ``gxbox-select`` from the
+  public package surface.
+- Repositioned ``pyampp`` as the main GUI application and clarified the distinct
+  roles of ``gxbox-view2d``, ``gxbox-view3d``, and ``gxrefmap-view``.
+- ``h5tree`` now prints ``metadata/*`` values by default; replaced ``--show-metadata``
+  with ``--no-metadata`` and added ``--meta`` for metadata-only output.
+- Simplified GUI launcher commands: removed ``gxampp`` alias; use ``pyampp`` as
+  the single launcher.
+- Added a DRMS downloader backend and made it the default backend; added
+  ``--use-fido`` and ``--force-download`` CLI options.
+- Improved DRMS downloader throughput by scheduling independent HMI/AIA requests
+  concurrently.
+- Added GUI downloader controls (``Downloader`` selector and ``Use cache`` checkbox)
+  and GUI command-export actions (copy command, save shell script).
+- Implemented DRMS normalization of raw JSOC exports into reusable local FITS
+  files and fixed DRMS nearest-record selection for HMI products.
+- Reworked ``Vert_current`` generation to use an IDL-style remapped-input path
+  plus a vectorized NumPy kernel.
+- Fixed 2D viewer loading of embedded-only maps such as ``Vert_current`` when
+  ``Map Source`` is set to ``Filesystem``.
+- Added redundant derived ``observer/pb0r`` metadata alongside canonical
+  ``observer/ephemeris`` for SSW-style ``B0 / L0 / Rsun`` interoperability.
 
 Packaging/versioning:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@
 # -- Project information -----------------------------------------------------
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.4"
+release = "1.0.5"
 
 project = "pyAMPP"
 copyright = "2022, suncast-org"

--- a/pyampp/_version.py
+++ b/pyampp/_version.py
@@ -1,3 +1,3 @@
 """Canonical package version."""
 
-version = "1.0.4"
+version = "1.0.5"

--- a/pyampp/data/downloader.py
+++ b/pyampp/data/downloader.py
@@ -288,7 +288,7 @@ class SDOImageDownloader:
             self.existence_report = self._download_images_fido()
         return self.existence_report
 
-    def _fetch_product(self, backend, job):
+    def _fetch_drms_product(self, job):
         return self._drms_get_fits(
             job["series"],
             job["segment"],
@@ -296,9 +296,9 @@ class SDOImageDownloader:
             time_window=job["time_window"],
         )
 
-    def _download_images_resolved(self, backend):
+    def _download_images_resolved(self):
         self._drms_throttle_seen = False
-        if backend == "drms" and self.drms_sequential:
+        if self.drms_sequential:
             print("DRMS sequential mode enabled: forcing single-worker downloads")
 
         specs = self._iter_product_specs()
@@ -322,12 +322,12 @@ class SDOImageDownloader:
             failed = []
             max_workers = max(1, min(workers, len(jobs)))
             if len(jobs) > 1:
-                print(f"{backend.upper()}: downloading {len(jobs)} {label} products with up to {max_workers} workers")
+                print(f"DRMS: downloading {len(jobs)} {label} products with up to {max_workers} workers")
             with ThreadPoolExecutor(max_workers=max_workers) as pool:
                 future_to_job = {}
                 for job in jobs:
                     print(job["label"])
-                    future_to_job[pool.submit(self._fetch_product, backend, job)] = job
+                    future_to_job[pool.submit(self._fetch_drms_product, job)] = job
                 for future in as_completed(future_to_job):
                     job = future_to_job[future]
                     try:
@@ -336,30 +336,26 @@ class SDOImageDownloader:
                             failed.append(job)
                     except Exception as exc:
                         print(
-                            f"{backend.upper()} task failed for "
+                            f"DRMS task failed for "
                             f"{job['series']}{{{job['segment']}}}: {exc}"
                         )
                         files[job["key"]] = ""
                         failed.append(job)
             return failed
 
-        if backend == "drms":
-            hmi_workers = 1 if self.drms_sequential else self.DRMS_HMI_MAX_WORKERS
-            _run_jobs(hmi_jobs, hmi_workers, "HMI")
-            context_workers = 1 if self.drms_sequential else self.DRMS_MAX_WORKERS
-            failed_context = _run_jobs(aia_jobs, context_workers, "AIA")
-            if failed_context and context_workers > 1 and self._drms_throttle_seen:
-                retry_jobs = [job for job in failed_context if not files.get(job["key"])]
-                if retry_jobs:
-                    print(
-                        "DRMS throttling detected during AIA parallel fetch; "
-                        "retrying missing AIA products sequentially"
-                    )
-                    self._drms_throttle_seen = False
-                    _run_jobs(retry_jobs, 1, "AIA retry")
-        else:
-            _run_jobs(hmi_jobs, 1, "HMI")
-            _run_jobs(aia_jobs, 1, "AIA")
+        hmi_workers = 1 if self.drms_sequential else self.DRMS_HMI_MAX_WORKERS
+        _run_jobs(hmi_jobs, hmi_workers, "HMI")
+        context_workers = 1 if self.drms_sequential else self.DRMS_MAX_WORKERS
+        failed_context = _run_jobs(aia_jobs, context_workers, "AIA")
+        if failed_context and context_workers > 1 and self._drms_throttle_seen:
+            retry_jobs = [job for job in failed_context if not files.get(job["key"])]
+            if retry_jobs:
+                print(
+                    "DRMS throttling detected during AIA parallel fetch; "
+                    "retrying missing AIA products sequentially"
+                )
+                self._drms_throttle_seen = False
+                _run_jobs(retry_jobs, 1, "AIA retry")
 
         return {key: (path or "") for key, path in files.items()}
 
@@ -430,7 +426,7 @@ class SDOImageDownloader:
         return {key: (path or "") for key, path in files.items()}
 
     def _download_images_drms(self):
-        return self._download_images_resolved("drms")
+        return self._download_images_resolved()
 
     def _fido_search(self, series, segment, time_window, wavelength=None, segments=None):
         t1, t2 = self._make_query_bounds(series, time_window)

--- a/pyampp/data/downloader.py
+++ b/pyampp/data/downloader.py
@@ -117,14 +117,21 @@ class SDOImageDownloader:
         }
         return patterns
 
+    def _local_match_tolerance_seconds(self, series, time_window):
+        """Half the JSOC query span, matching ``_make_query_bounds()``."""
+        return self._query_window_seconds(series, time_window) / 2.0
+
     def _time_tolerances(self):
-        uv_seconds = max(self.aia_time_window, 24) if self.uv else self.aia_time_window
+        euv_seconds = self._local_match_tolerance_seconds("aia.lev1_euv_12s", self.aia_time_window)
+        uv_window = max(self.aia_time_window, 24) if self.uv else self.aia_time_window
+        uv_seconds = self._local_match_tolerance_seconds("aia.lev1_uv_24s", uv_window)
+        hmi_seconds = self._local_match_tolerance_seconds("hmi.B_720s", self.hmi_time_window)
         return {
-            "euv": timedelta(seconds=self.aia_time_window),
+            "euv": timedelta(seconds=euv_seconds),
             "uv": timedelta(seconds=uv_seconds),
-            "hmi_b": timedelta(seconds=self.hmi_time_window),
-            "hmi_m": timedelta(seconds=self.hmi_time_window),
-            "hmi_ic": timedelta(seconds=self.hmi_time_window),
+            "hmi_b": timedelta(seconds=hmi_seconds),
+            "hmi_m": timedelta(seconds=hmi_seconds),
+            "hmi_ic": timedelta(seconds=hmi_seconds),
         }
 
     @staticmethod
@@ -160,11 +167,7 @@ class SDOImageDownloader:
         return best_path
 
     def _tolerance_seconds_for_series(self, series, time_window):
-        if str(series or "").lower().startswith("hmi."):
-            return float(self.hmi_time_window)
-        if str(series or "").lower().startswith("aia.lev1_uv"):
-            return float(max(time_window, 24))
-        return float(time_window)
+        return self._local_match_tolerance_seconds(series, time_window)
 
     def _make_query_bounds(self, series, time_window):
         query_window = self._query_window_seconds(series, time_window)
@@ -286,14 +289,7 @@ class SDOImageDownloader:
         return self.existence_report
 
     def _fetch_product(self, backend, job):
-        if backend == "drms":
-            return self._drms_get_fits(
-                job["series"],
-                job["segment"],
-                wave=job["wave"],
-                time_window=job["time_window"],
-            )
-        return self._fido_fetch_product(
+        return self._drms_get_fits(
             job["series"],
             job["segment"],
             wave=job["wave"],
@@ -368,56 +364,141 @@ class SDOImageDownloader:
         return {key: (path or "") for key, path in files.items()}
 
     def _download_images_fido(self):
-        return self._download_images_resolved("fido")
+        specs = self._iter_product_specs()
+        files = {}
+        for spec in specs:
+            path = self._try_resolve_local(
+                spec["series"],
+                spec["segment"],
+                spec["wave"],
+                spec["time_window"],
+                spec["patterns"],
+            )
+            files[spec["key"]] = path or None
+
+        hmi_missing = [spec for spec in specs if spec["pool"] == "hmi" and not files.get(spec["key"])]
+        euv_missing = [
+            spec
+            for spec in specs
+            if spec["series"] == "aia.lev1_euv_12s" and not files.get(spec["key"])
+        ]
+        uv_missing = [
+            spec
+            for spec in specs
+            if spec["series"] == "aia.lev1_uv_24s" and not files.get(spec["key"])
+        ]
+
+        if hmi_missing:
+            self._fido_fetch_hmi_batch(hmi_missing)
+            for spec in hmi_missing:
+                path = self._try_resolve_local(
+                    spec["series"],
+                    spec["segment"],
+                    spec["wave"],
+                    spec["time_window"],
+                    spec["patterns"],
+                )
+                if path:
+                    files[spec["key"]] = path
+
+        if euv_missing:
+            self._fido_fetch_aia_batch(euv_missing)
+            for spec in euv_missing:
+                path = self._try_resolve_local(
+                    spec["series"],
+                    spec["segment"],
+                    spec["wave"],
+                    spec["time_window"],
+                    spec["patterns"],
+                )
+                if path:
+                    files[spec["key"]] = path
+
+        if uv_missing:
+            self._fido_fetch_aia_batch(uv_missing)
+            for spec in uv_missing:
+                path = self._try_resolve_local(
+                    spec["series"],
+                    spec["segment"],
+                    spec["wave"],
+                    spec["time_window"],
+                    spec["patterns"],
+                )
+                if path:
+                    files[spec["key"]] = path
+
+        return {key: (path or "") for key, path in files.items()}
 
     def _download_images_drms(self):
         return self._download_images_resolved("drms")
 
-    def _fido_fetch_product(self, series, segment, wave=None, time_window=12):
+    def _fido_search(self, series, segment, time_window, wavelength=None, segments=None):
         t1, t2 = self._make_query_bounds(series, time_window)
-        query_key = self._make_query_key(t1, t2, series, segment, wave=wave)
-
         notify_email = jsoc_notify_email()
         search_attrs = [a.Time(t1, t2), a.jsoc.Series(series), a.jsoc.Notify(notify_email)]
-        if wave is not None:
-            search_attrs.insert(-1, a.Wavelength(int(wave) * u.AA))
-        search_attrs.insert(-1, a.jsoc.Segment(segment))
-
-        print(f"Searching for {series} with attributes {search_attrs}")
+        if wavelength is not None:
+            search_attrs.insert(-1, wavelength)
+        segment_attr = segments if segments is not None else a.jsoc.Segment(segment)
+        search_attrs.insert(-1, segment_attr)
+        print(f"Fido: searching {series} with {len(search_attrs)} attribute(s)")
         result = Fido.search(*search_attrs)
-        print(f"Found {len(result)} records for download.")
-        if len(result) == 0:
-            return ""
+        print(f"Fido: found {len(result)} record(s) for {series}")
+        return result, t1, t2
 
-        fetched_files = Fido.fetch(
+    def _fido_fetch_search_result(self, result, streams=5):
+        if len(result) == 0:
+            return []
+        max_conn = max(1, min(int(streams), len(result)))
+        fetched = Fido.fetch(
             *result,
             path=self.path,
             overwrite=self.force_download,
-            max_conn=1,
+            max_conn=max_conn,
         )
-        print(f"Downloaded {len(fetched_files)} files.")
-        if not fetched_files:
-            return ""
+        print(f"Fido: downloaded {len(fetched)} file(s)")
+        return [str(item) for item in fetched]
 
-        best_path = ""
-        best_delta = None
-        target = self.time.datetime
-        for item in fetched_files:
-            path = str(item)
-            if not self._fits_has_map_metadata(path):
-                continue
-            file_dt = self._parse_filename_datetime(path)
-            if file_dt is None:
-                if not best_path:
-                    best_path = path
-                continue
-            delta = abs((file_dt - target).total_seconds())
-            if best_delta is None or delta < best_delta:
-                best_delta = delta
-                best_path = path
-        if best_path:
-            self._cache_store(query_key, best_path)
-        return best_path
+    def _fido_fetch_aia_batch(self, jobs):
+        if not jobs:
+            return
+        series = jobs[0]["series"]
+        segment = jobs[0]["segment"]
+        time_window = jobs[0]["time_window"]
+        waves = [job["wave"] for job in jobs]
+        wavelength_attr = a.AttrOr([a.Wavelength(int(wave) * u.AA) for wave in waves])
+        result, _, _ = self._fido_search(
+            series,
+            segment,
+            time_window,
+            wavelength=wavelength_attr,
+        )
+        self._fido_fetch_search_result(result, streams=len(waves))
+
+    def _fido_fetch_hmi_batch(self, jobs):
+        if not jobs:
+            return
+        by_series: dict[str, list] = {}
+        for job in jobs:
+            by_series.setdefault(job["series"], []).append(job)
+
+        for series, series_jobs in by_series.items():
+            time_window = series_jobs[0]["time_window"]
+            if series == "hmi.B_720s":
+                segments = [job["segment"] for job in series_jobs]
+                segment_attr = a.AttrAnd([a.jsoc.Segment(seg) for seg in segments])
+                result, _, _ = self._fido_search(
+                    series,
+                    series_jobs[0]["segment"],
+                    time_window,
+                    segments=segment_attr,
+                )
+            else:
+                result, _, _ = self._fido_search(
+                    series,
+                    series_jobs[0]["segment"],
+                    time_window,
+                )
+            self._fido_fetch_search_result(result, streams=len(series_jobs))
 
     def _load_cache_index(self):
         if not self._cache_index_path.exists():

--- a/pyampp/tests/test_downloader_cache_nearest.py
+++ b/pyampp/tests/test_downloader_cache_nearest.py
@@ -33,8 +33,45 @@ def test_find_nearest_cached_file_prefers_closer_hmi_bundle(tmp_path: Path) -> N
     )
 
     patterns = downloader._generate_filename_patterns(str(day_dir))["hmi_b"]["field"]
-    nearest = downloader._find_nearest_cached_file(patterns, downloader.hmi_time_window)
+    tolerance = downloader._tolerance_seconds_for_series("hmi.B_720s", downloader.hmi_time_window)
+    nearest = downloader._find_nearest_cached_file(patterns, tolerance)
     assert nearest == str(late)
+
+
+def test_local_match_tolerance_matches_query_bounds_half_window() -> None:
+    downloader = SDOImageDownloader(
+        Time("2026-04-03T19:46:37"),
+        backend="drms",
+        hmi_time_window=720,
+        aia_time_window=12,
+        hmi=False,
+        euv=True,
+        uv=True,
+    )
+    assert downloader._local_match_tolerance_seconds("aia.lev1_euv_12s", 12) == 6.0
+    assert downloader._local_match_tolerance_seconds("aia.lev1_uv_24s", 24) == 12.0
+    assert downloader._local_match_tolerance_seconds("hmi.B_720s", 720) == 720.0
+
+
+def test_find_nearest_cached_file_rejects_aia_outside_half_window(tmp_path: Path) -> None:
+    day_dir = tmp_path / "2026-04-03"
+    day_dir.mkdir()
+    far = day_dir / "aia.lev1_euv_12s.2026-04-03T194500Z.image.131.fits"
+    _write_map_fits(far, "2026-04-03T19:45:00")
+
+    downloader = SDOImageDownloader(
+        Time("2026-04-03T19:46:37"),
+        data_dir=str(tmp_path),
+        backend="drms",
+        hmi=False,
+        euv=True,
+        uv=False,
+        aia_time_window=12,
+    )
+    patterns = downloader._generate_filename_patterns(str(day_dir))["euv"]["131"]
+    tolerance = downloader._tolerance_seconds_for_series("aia.lev1_euv_12s", 12)
+    nearest = downloader._find_nearest_cached_file(patterns, tolerance)
+    assert nearest is None
 
 
 def test_try_resolve_local_uses_index_json_without_network(tmp_path: Path) -> None:

--- a/pyampp/tests/test_downloader_fido_batch.py
+++ b/pyampp/tests/test_downloader_fido_batch.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from astropy.time import Time
+
+import pyampp.data.downloader as downloader_mod
+from pyampp.data.downloader import SDOImageDownloader
+
+
+def test_download_images_fido_batches_aia_wavelengths(monkeypatch, tmp_path: Path) -> None:
+    when = Time("2026-04-03T19:46:37")
+    downloader = SDOImageDownloader(
+        when,
+        data_dir=str(tmp_path),
+        backend="fido",
+        force_download=False,
+        hmi=False,
+        euv=True,
+        uv=False,
+    )
+
+    search_calls = []
+    fetch_calls = []
+
+    def fake_search(*args, **kwargs):
+        search_calls.append(args)
+        result = MagicMock()
+        result.__len__.return_value = 1
+        return result
+
+    def fake_fetch(*args, **kwargs):
+        fetch_calls.append(args)
+        return []
+
+    monkeypatch.setattr(downloader_mod.Fido, "search", fake_search)
+    monkeypatch.setattr(downloader_mod.Fido, "fetch", fake_fetch)
+    monkeypatch.setattr(downloader, "_try_resolve_local", lambda *_args, **_kwargs: "")
+
+    downloader._download_images_fido()
+
+    assert len(search_calls) == 1
+    assert len(fetch_calls) == 1
+
+
+def test_download_images_fido_batches_hmi_segments(monkeypatch, tmp_path: Path) -> None:
+    when = Time("2026-04-03T19:46:37")
+    downloader = SDOImageDownloader(
+        when,
+        data_dir=str(tmp_path),
+        backend="fido",
+        force_download=False,
+        hmi=True,
+        euv=False,
+        uv=False,
+    )
+
+    search_calls = []
+
+    def fake_search(*args, **kwargs):
+        search_calls.append(args)
+        result = MagicMock()
+        result.__len__.return_value = 1
+        return result
+
+    monkeypatch.setattr(downloader_mod.Fido, "search", fake_search)
+    monkeypatch.setattr(downloader_mod.Fido, "fetch", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(downloader, "_try_resolve_local", lambda *_args, **_kwargs: "")
+
+    downloader._download_images_fido()
+
+    # hmi.B_720s (4 segments), hmi.M_720s, hmi.Ic_noLimbDark_720s
+    assert len(search_calls) == 3

--- a/pyampp/version.py
+++ b/pyampp/version.py
@@ -4,4 +4,4 @@ try:
     from ._version import version
 except Exception:
     # Fallback for editable/local source trees where _version.py is absent.
-    version = "1.0.4"
+    version = "1.0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyampp"
-version = "1.0.4"
+version = "1.0.5"
 description = "Python Automatic Model Production Pipeline"
 readme = "README.rst"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Follow-up to Copilot review comments on PRs #46 and #48.

- **PR #46 (CHANGELOG):** moved previously shipped notes from `Unreleased` into the `1.0.3` section (and documented this cleanup in `1.0.5`).
- **PR #48 (tolerance):** local cache matching now uses half the JSOC query window via `_local_match_tolerance_seconds()`, consistent with `_make_query_bounds()` (±query_window/2).
- **PR #48 (Fido perf):** restored batched `Fido.search` / `Fido.fetch` for AIA wavelength groups and HMI segment groups instead of one network round-trip per product.

## Test plan

- [x] `pytest pyampp/tests/test_downloader_cache_nearest.py` — half-window tolerance + out-of-window rejection
- [x] `pytest pyampp/tests/test_downloader_fido_batch.py` — one EUV search, three HMI series searches
- [x] `pytest pyampp/tests/test_downloader_drms_parallel.py` — DRMS orchestration unchanged
- [x] `pytest pyampp/tests/test_fov2box_time_anchor.py` — continuum anchor unchanged


Made with [Cursor](https://cursor.com)